### PR TITLE
feat: encrypt seller Cashu tokens in database

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -11,3 +11,7 @@ MINT_URL=https://mint.minibits.cash/Bitcoin
 
 # Database path (can be absolute or relative)
 # DB_PATH=./stashu.db
+
+# Token encryption key (64 hex chars = 32 bytes for AES-256-GCM)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+TOKEN_ENCRYPTION_KEY=

--- a/server/src/lib/autosettle.ts
+++ b/server/src/lib/autosettle.ts
@@ -1,6 +1,7 @@
 import db from '../db/index.js';
 import { resolveAddress } from './lnaddress.js';
 import { meltToLightning, getMeltQuote } from './cashu.js';
+import { decrypt } from './encryption.js';
 
 interface SettingsRow {
   pubkey: string;
@@ -130,7 +131,7 @@ export async function tryAutoSettle(sellerPubkey: string): Promise<void> {
     }
 
     // 5. Melt tokens to pay the invoice
-    const tokenStrings = tokens.map((t) => t.seller_token);
+    const tokenStrings = tokens.map((t) => decrypt(t.seller_token));
     const meltResult = await meltToLightning(tokenStrings, finalInvoice);
 
     if (!meltResult.success) {

--- a/server/src/lib/encryption.ts
+++ b/server/src/lib/encryption.ts
@@ -1,0 +1,93 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+/**
+ * AES-256-GCM encryption for Cashu seller tokens.
+ *
+ * Reads TOKEN_ENCRYPTION_KEY from env (64 hex chars = 32 bytes).
+ * Encrypted format: iv:authTag:ciphertext (all hex-encoded).
+ *
+ * Each encryption uses a random IV, so encrypting the same token
+ * twice produces different ciphertexts — this prevents pattern analysis.
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // 96-bit IV recommended for GCM
+const AUTH_TAG_LENGTH = 16; // 128-bit auth tag
+
+function getEncryptionKey(): Buffer {
+  const keyHex = process.env.TOKEN_ENCRYPTION_KEY;
+
+  if (!keyHex) {
+    throw new Error(
+      'TOKEN_ENCRYPTION_KEY environment variable is not set. ' +
+        "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
+    );
+  }
+
+  if (keyHex.length !== 64) {
+    throw new Error(
+      `TOKEN_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes). Got ${keyHex.length} characters.`
+    );
+  }
+
+  return Buffer.from(keyHex, 'hex');
+}
+
+/**
+ * Encrypt a plaintext string (e.g. a Cashu token) using AES-256-GCM.
+ * @param plaintext The string to encrypt
+ * @returns Encrypted string in format "iv:authTag:ciphertext" (hex-encoded)
+ */
+export function encrypt(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+
+  const authTag = cipher.getAuthTag();
+
+  // Format: iv:authTag:ciphertext
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+}
+
+/**
+ * Decrypt an encrypted string back to plaintext.
+ * @param encryptedString String in format "iv:authTag:ciphertext" (hex-encoded)
+ * @returns The original plaintext string
+ */
+export function decrypt(encryptedString: string): string {
+  // Backward compatibility: if this is a plaintext Cashu token (not yet encrypted),
+  // return it as-is. All Cashu tokens start with 'cashu' (e.g. cashuA..., cashuB...).
+  // This allows a smooth migration from plaintext → encrypted without a separate script.
+  if (encryptedString.startsWith('cashu')) {
+    return encryptedString;
+  }
+
+  const key = getEncryptionKey();
+
+  const parts = encryptedString.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted token format. Expected "iv:authTag:ciphertext".');
+  }
+
+  const [ivHex, authTagHex, ciphertext] = parts;
+
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  decipher.setAuthTag(authTag);
+
+  let decrypted = decipher.update(ciphertext, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+
+  return decrypted;
+}

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
+import { decrypt } from '../lib/encryption.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type {
   DashboardResponse,
@@ -59,7 +60,7 @@ dashboardRoutes.get('/:pubkey', async (c) => {
       price_sats: number;
     }>;
 
-    const tokens = tokenRows.map((r) => r.seller_token);
+    const tokens = tokenRows.map((r) => decrypt(r.seller_token));
     const totalSats = tokenRows.reduce((sum, r) => sum + r.price_sats, 0);
 
     return c.json<APIResponse<DashboardResponse>>({

--- a/server/src/routes/earnings.ts
+++ b/server/src/routes/earnings.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
+import { decrypt } from '../lib/encryption.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type { EarningsResponse, APIResponse } from '../../../shared/types.js';
 
@@ -20,7 +21,7 @@ earningsRoutes.get('/:pubkey', async (c) => {
 
     const results = stmt.all(pubkey) as Array<{ seller_token: string; price_sats: number }>;
 
-    const tokens = results.map((r) => r.seller_token);
+    const tokens = results.map((r) => decrypt(r.seller_token));
     const totalSats = results.reduce((sum, r) => sum + r.price_sats, 0);
 
     return c.json<APIResponse<EarningsResponse>>({

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -6,6 +6,7 @@ import {
   mintAfterPayment,
   verifyAndSwapToken,
 } from '../lib/cashu.js';
+import { encrypt } from '../lib/encryption.js';
 import type { PayInvoiceResponse, PayStatusResponse, APIResponse } from '../../../shared/types.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 
@@ -131,7 +132,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
       // Store successful payment
       db.prepare(
         `UPDATE payments SET status = 'paid', seller_token = ?, paid_at = unixepoch() WHERE id = ?`
-      ).run(swapResult.sellerToken, paymentId);
+      ).run(encrypt(swapResult.sellerToken!), paymentId);
 
       // Trigger auto-settlement check (fire-and-forget)
       tryAutoSettle(stash.seller_pubkey).catch(() => {});

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { createHash } from 'crypto';
 import db from '../db/index.js';
 import { verifyAndSwapToken } from '../lib/cashu.js';
+import { encrypt } from '../lib/encryption.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 import type { UnlockRequest, UnlockResponse, APIResponse } from '../../../shared/types.js';
 
@@ -107,7 +108,7 @@ unlockRoutes.post('/:id', async (c) => {
       SET status = 'paid', seller_token = ?, paid_at = unixepoch()
       WHERE id = ?
     `
-    ).run(swapResult.sellerToken, paymentId);
+    ).run(encrypt(swapResult.sellerToken!), paymentId);
 
     // Trigger auto-settlement check (fire-and-forget)
     tryAutoSettle(stash.seller_pubkey).catch(() => {});

--- a/server/src/routes/withdraw.ts
+++ b/server/src/routes/withdraw.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
 import { getMeltQuote, meltToLightning } from '../lib/cashu.js';
+import { decrypt } from '../lib/encryption.js';
 import { resolveAddress } from '../lib/lnaddress.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type {
@@ -107,7 +108,7 @@ withdrawRoutes.post('/execute', async (c) => {
       );
     }
 
-    const tokens = tokenRows.map((r) => r.seller_token);
+    const tokens = tokenRows.map((r) => decrypt(r.seller_token));
     const paymentIds = tokenRows.map((r) => r.payment_id);
     const totalSats = tokenRows.reduce((sum, r) => sum + r.price_sats, 0);
 


### PR DESCRIPTION
Fixes #8 
Encrypt seller Cashu tokens with AES-256-GCM before storing in DB. Decrypt on read. Backward compatible with existing plaintext tokens.