### PR TITLE
Encrypt seller tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ git clone https://github.com/keshav0479/Stashu.git
 cd Stashu
 npm install
 
-# Configure environment (optional — defaults work for local dev)
+# Configure environment
 cp server/.env.example server/.env
-cp client/.env.example client/.env
+# ⚠️ server/.env requires TOKEN_ENCRYPTION_KEY — generate one:
+# node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+cp client/.env.example client/.env  # Optional — defaults work for local dev
 
 npm run dev
 ```
@@ -72,11 +75,12 @@ npm run dev
 
 ### What is NOT encrypted (known limitations)
 
-| Data              | Where                      | Risk                                                    | Why it's there                                                              |
-| ----------------- | -------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `secret_key`      | Server DB (stashes table)  | Server admin can decrypt files                          | Required for async pay-to-unlock — buyer and seller don't interact directly |
-| `seller_token`    | Server DB (payments table) | Server admin could spend tokens before seller withdraws | Server acts as escrow until seller withdraws                                |
-| Nostr private key | Browser localStorage       | XSS could steal nsec                                    | Same pattern as every Nostr web client; recoverable via nsec backup         |
+| Data              | Where                     | Risk                           | Why it's there                                                              |
+| ----------------- | ------------------------- | ------------------------------ | --------------------------------------------------------------------------- |
+| `secret_key`      | Server DB (stashes table) | Server admin can decrypt files | Required for async pay-to-unlock — buyer and seller don't interact directly |
+| Nostr private key | Browser localStorage      | XSS could steal nsec           | Same pattern as every Nostr web client; recoverable via nsec backup         |
+
+> **Note:** `seller_token` is encrypted at rest using XChaCha20-Poly1305 (requires `TOKEN_ENCRYPTION_KEY`).
 
 ### V2 Roadmap (removing trust)
 
@@ -85,7 +89,6 @@ These changes will eliminate the need to trust the server:
 1. **Client-to-buyer key exchange** — Deliver decryption keys via Nostr DMs instead of through the server. Server never sees `secret_key`.
 2. **Non-custodial token swaps** — Direct buyer-to-seller token transfer or DLC-based escrow. Server never holds `seller_token`.
 3. **Multi-mint support** — Eliminate single-mint dependency.
-4. **Encrypted token storage** — If tokens must touch the server, encrypt them at rest with seller's pubkey.
 
 ## Roadmap
 
@@ -116,7 +119,6 @@ These changes will eliminate the need to trust the server:
 
 - [ ] Client-to-buyer key exchange (zero-knowledge file access)
 - [ ] Non-custodial token swaps (remove server custody)
-- [ ] Encrypted token storage at rest
 - [ ] Multiple Cashu mints
 - [ ] WebLN integration
 - [ ] Nostr Wallet Connect

--- a/package-lock.json
+++ b/package-lock.json
@@ -5608,6 +5608,7 @@
       "dependencies": {
         "@cashu/cashu-ts": "^2.0.0",
         "@hono/node-server": "^1.8.0",
+        "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",
         "better-sqlite3": "^11.0.0",
         "hono": "^4.0.0",

--- a/server/.env.example
+++ b/server/.env.example
@@ -11,3 +11,7 @@ MINT_URL=https://mint.minibits.cash/Bitcoin
 
 # Database path (can be absolute or relative)
 # DB_PATH=./stashu.db
+
+# Token encryption key (64 hex chars = 32 bytes for XChaCha20-Poly1305)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+TOKEN_ENCRYPTION_KEY=

--- a/server/package.json
+++ b/server/package.json
@@ -3,13 +3,15 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
-    "start": "node dist/server/src/index.js"
+    "start": "node --env-file=.env dist/server/src/index.js",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@cashu/cashu-ts": "^2.0.0",
     "@hono/node-server": "^1.8.0",
+    "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^2.0.1",
     "better-sqlite3": "^11.0.0",
     "hono": "^4.0.0",

--- a/server/src/db/migration.test.ts
+++ b/server/src/db/migration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the DB startup logic: plaintext migration + key-rotation probe.
+ *
+ * These tests exercise the same logic that runs in db/index.ts on startup,
+ * but in isolation using an in-memory SQLite database.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+
+// Ensure a valid key is set for tests
+if (!process.env.TOKEN_ENCRYPTION_KEY) {
+  const { randomBytes } = await import('node:crypto');
+  process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+}
+
+const { encrypt, decrypt } = await import('../lib/encryption.js');
+
+/**
+ * Re-implement the startup logic from db/index.ts as testable functions.
+ * This mirrors the actual code paths without process.exit().
+ */
+
+function migrateAndProbe(db: InstanceType<typeof Database>): {
+  migrated: number;
+  probeErrors: string[];
+} {
+  const probeErrors: string[] = [];
+
+  // 1. Key-rotation probe: try decrypting ALL encrypted rows
+  const encryptedRows = db
+    .prepare(
+      `SELECT id, seller_token FROM payments
+       WHERE seller_token IS NOT NULL AND seller_token NOT LIKE 'cashu%'`
+    )
+    .all() as Array<{ id: string; seller_token: string }>;
+
+  for (const row of encryptedRows) {
+    try {
+      decrypt(row.seller_token);
+    } catch {
+      probeErrors.push(row.id);
+    }
+  }
+
+  // 2. Plaintext migration: encrypt any cashu* tokens
+  const plaintextRows = db
+    .prepare(
+      `SELECT id, seller_token FROM payments WHERE seller_token IS NOT NULL AND seller_token LIKE 'cashu%'`
+    )
+    .all() as Array<{ id: string; seller_token: string }>;
+
+  if (plaintextRows.length > 0) {
+    const update = db.prepare(`UPDATE payments SET seller_token = ? WHERE id = ?`);
+    const tx = db.transaction(() => {
+      for (const row of plaintextRows) {
+        update.run(encrypt(row.seller_token), row.id);
+      }
+    });
+    tx();
+  }
+
+  return { migrated: plaintextRows.length, probeErrors };
+}
+
+function createTestDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE stashes (
+      id TEXT PRIMARY KEY,
+      blob_url TEXT NOT NULL,
+      secret_key TEXT NOT NULL,
+      seller_pubkey TEXT NOT NULL,
+      price_sats INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      file_name TEXT NOT NULL DEFAULT 'file',
+      file_size INTEGER NOT NULL,
+      created_at INTEGER DEFAULT (unixepoch())
+    );
+    CREATE TABLE payments (
+      id TEXT PRIMARY KEY,
+      stash_id TEXT NOT NULL,
+      status TEXT DEFAULT 'pending',
+      token_hash TEXT NOT NULL,
+      seller_token TEXT,
+      claimed INTEGER DEFAULT 0,
+      created_at INTEGER DEFAULT (unixepoch()),
+      paid_at INTEGER
+    );
+  `);
+  return db;
+}
+
+describe('DB migration: plaintext → encrypted', () => {
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('migrates plaintext cashu tokens', () => {
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p1', 's1', 'paid', 'hash1', 'cashuAtoken123')`
+    ).run();
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p2', 's1', 'paid', 'hash2', 'cashuBtoken456')`
+    ).run();
+
+    const result = migrateAndProbe(db);
+
+    assert.equal(result.migrated, 2, 'should migrate 2 plaintext tokens');
+    assert.equal(result.probeErrors.length, 0, 'no probe errors');
+
+    // Verify tokens are now encrypted
+    const rows = db.prepare(`SELECT seller_token FROM payments`).all() as Array<{
+      seller_token: string;
+    }>;
+    for (const row of rows) {
+      assert.ok(!row.seller_token.startsWith('cashu'), 'should no longer be plaintext');
+      assert.ok(row.seller_token.includes(':'), 'should be in nonce:ciphertext format');
+    }
+  });
+
+  it('skips rows without seller_token', () => {
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p1', 's1', 'pending', 'hash1', NULL)`
+    ).run();
+
+    const result = migrateAndProbe(db);
+
+    assert.equal(result.migrated, 0);
+    assert.equal(result.probeErrors.length, 0);
+  });
+
+  it('leaves already-encrypted tokens untouched', () => {
+    const encrypted = encrypt('cashuOriginalToken');
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p1', 's1', 'paid', 'hash1', ?)`
+    ).run(encrypted);
+
+    const result = migrateAndProbe(db);
+
+    assert.equal(result.migrated, 0, 'should not re-encrypt');
+    assert.equal(result.probeErrors.length, 0, 'should decrypt fine');
+
+    const row = db.prepare(`SELECT seller_token FROM payments WHERE id = 'p1'`).get() as {
+      seller_token: string;
+    };
+    assert.equal(row.seller_token, encrypted, 'ciphertext should be unchanged');
+  });
+});
+
+describe('DB startup probe: key-rotation detection', () => {
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it('passes when all rows decrypt successfully', () => {
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p1', 's1', 'paid', 'hash1', ?)`
+    ).run(encrypt('token1'));
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p2', 's1', 'paid', 'hash2', ?)`
+    ).run(encrypt('token2'));
+
+    const result = migrateAndProbe(db);
+    assert.equal(result.probeErrors.length, 0);
+  });
+
+  it('detects wrong-key rows', () => {
+    // Encrypt with current key
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p1', 's1', 'paid', 'hash1', ?)`
+    ).run(encrypt('token1'));
+
+    // Insert garbage that looks like encrypted data but uses wrong key
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('p2', 's1', 'paid', 'hash2', ?)`
+    ).run(
+      'aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabb:deadbeef0011223344'
+    );
+
+    const result = migrateAndProbe(db);
+    assert.equal(result.probeErrors.length, 1, 'should flag 1 bad row');
+    assert.equal(result.probeErrors[0], 'p2', 'should identify the bad payment');
+  });
+
+  it('detects mixed DB (some good, some bad)', () => {
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('good1', 's1', 'paid', 'h1', ?)`
+    ).run(encrypt('token1'));
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('good2', 's1', 'paid', 'h2', ?)`
+    ).run(encrypt('token2'));
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token)
+                VALUES ('bad1', 's1', 'paid', 'h3', ?)`
+    ).run('ff'.repeat(24) + ':' + 'aa'.repeat(32));
+
+    const result = migrateAndProbe(db);
+    assert.equal(result.probeErrors.length, 1, 'should catch the bad row among good ones');
+    assert.equal(result.probeErrors[0], 'bad1');
+  });
+
+  it('passes on empty DB', () => {
+    const result = migrateAndProbe(db);
+    assert.equal(result.probeErrors.length, 0);
+    assert.equal(result.migrated, 0);
+  });
+});

--- a/server/src/lib/autosettle.ts
+++ b/server/src/lib/autosettle.ts
@@ -1,6 +1,7 @@
 import db from '../db/index.js';
 import { resolveAddress } from './lnaddress.js';
 import { meltToLightning, getMeltQuote } from './cashu.js';
+import { decrypt } from './encryption.js';
 
 interface SettingsRow {
   pubkey: string;
@@ -130,7 +131,7 @@ export async function tryAutoSettle(sellerPubkey: string): Promise<void> {
     }
 
     // 5. Melt tokens to pay the invoice
-    const tokenStrings = tokens.map((t) => t.seller_token);
+    const tokenStrings = tokens.map((t) => decrypt(t.seller_token));
     const meltResult = await meltToLightning(tokenStrings, finalInvoice);
 
     if (!meltResult.success) {

--- a/server/src/lib/encryption.test.ts
+++ b/server/src/lib/encryption.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for encryption.ts
+ *
+ * Run with:
+ *   TOKEN_ENCRYPTION_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))") npx tsx --test server/src/lib/encryption.test.ts
+ *
+ * Or from the server workspace:
+ *   npm test
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Ensure a valid key is set for tests
+if (!process.env.TOKEN_ENCRYPTION_KEY) {
+  const { randomBytes } = await import('node:crypto');
+  process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+}
+
+const { encrypt, decrypt } = await import('./encryption.js');
+
+describe('encrypt/decrypt', () => {
+  it('roundtrip: encrypt then decrypt returns original', () => {
+    const original = 'cashuBpGhhdGlkWCDLZ2OlqLihRkNTaiDDXz2bVEuNKk6VKN';
+    const encrypted = encrypt(original);
+    assert.notEqual(encrypted, original, 'encrypted should differ from original');
+    assert.ok(encrypted.includes(':'), 'should have nonce:ciphertext format');
+    const decrypted = decrypt(encrypted);
+    assert.equal(decrypted, original);
+  });
+
+  it('same input produces different ciphertexts (random nonce)', () => {
+    const plaintext = 'some_token_value';
+    const a = encrypt(plaintext);
+    const b = encrypt(plaintext);
+    assert.notEqual(a, b, 'two encryptions of same input should differ');
+    assert.equal(decrypt(a), plaintext);
+    assert.equal(decrypt(b), plaintext);
+  });
+
+  it('handles empty string', () => {
+    const encrypted = encrypt('');
+    const decrypted = decrypt(encrypted);
+    assert.equal(decrypted, '');
+  });
+
+  it('handles long tokens', () => {
+    const longToken = 'x'.repeat(10_000);
+    const encrypted = encrypt(longToken);
+    assert.equal(decrypt(encrypted), longToken);
+  });
+});
+
+describe('decrypt backward compat', () => {
+  it('plaintext cashu tokens pass through unchanged', () => {
+    const token = 'cashuABCD1234tokendata';
+    const result = decrypt(token);
+    assert.equal(result, token, 'plaintext cashu token should be returned as-is');
+  });
+
+  it('plaintext cashu with special chars passes through', () => {
+    const token = 'cashuBpGhhdGlkWCDLZ2OlqL==+/';
+    assert.equal(decrypt(token), token);
+  });
+});
+
+describe('error handling', () => {
+  it('corrupted ciphertext throws', () => {
+    const encrypted = encrypt('test');
+    const parts = encrypted.split(':');
+    // Corrupt the ciphertext by flipping bytes
+    const corrupted = `${parts[0]}:${'ff'.repeat(parts[1].length / 2)}`;
+    assert.throws(() => decrypt(corrupted), 'should throw on corrupted data');
+  });
+
+  it('invalid format (too many parts) throws', () => {
+    assert.throws(() => decrypt('aa:bb:cc'), 'should throw on 3-part format');
+  });
+
+  it('invalid format (no colon) throws', () => {
+    assert.throws(() => decrypt('notencryptednotcashu'), 'should throw on non-cashu single part');
+  });
+
+  it('wrong key fails to decrypt', async () => {
+    // Encrypt with current key
+    const encrypted = encrypt('secret_token');
+
+    // Swap to a different key
+    const originalKey = process.env.TOKEN_ENCRYPTION_KEY;
+    const { randomBytes } = await import('node:crypto');
+    process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+
+    try {
+      assert.throws(() => decrypt(encrypted), 'wrong key should fail');
+    } finally {
+      // Restore original key
+      process.env.TOKEN_ENCRYPTION_KEY = originalKey;
+    }
+  });
+});

--- a/server/src/lib/encryption.ts
+++ b/server/src/lib/encryption.ts
@@ -1,0 +1,98 @@
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { randomBytes } from 'crypto';
+
+/**
+ * XChaCha20-Poly1305 encryption for Cashu seller tokens.
+ *
+ * Uses the same algorithm as the client-side Blossom file encryption.
+ * Reads TOKEN_ENCRYPTION_KEY from env (64 hex chars = 32 bytes).
+ * Encrypted format: nonce:ciphertext (both hex-encoded).
+ *
+ * Each encryption uses a random 24-byte nonce, so encrypting the same
+ * token twice produces different ciphertexts — this prevents pattern analysis.
+ */
+
+const NONCE_LENGTH = 24; // XChaCha20 uses 24-byte nonces
+
+function getEncryptionKey(): Uint8Array {
+  const keyHex = process.env.TOKEN_ENCRYPTION_KEY;
+
+  if (!keyHex) {
+    throw new Error(
+      'TOKEN_ENCRYPTION_KEY environment variable is not set. ' +
+        "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
+    );
+  }
+
+  if (!/^[0-9a-fA-F]{64}$/.test(keyHex)) {
+    throw new Error(
+      `TOKEN_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes). ` +
+        `Got ${keyHex.length} characters. Ensure it contains only 0-9 and a-f.`
+    );
+  }
+
+  return hexToBytes(keyHex);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error('Invalid hex string');
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Encrypt a plaintext string (e.g. a Cashu token) using XChaCha20-Poly1305.
+ * @param plaintext The string to encrypt
+ * @returns Encrypted string in format "nonce:ciphertext" (hex-encoded)
+ */
+export function encrypt(plaintext: string): string {
+  const key = getEncryptionKey();
+  const nonce = new Uint8Array(randomBytes(NONCE_LENGTH));
+  const cipher = xchacha20poly1305(key, nonce);
+  const ciphertext = cipher.encrypt(new TextEncoder().encode(plaintext));
+
+  return `${bytesToHex(nonce)}:${bytesToHex(ciphertext)}`;
+}
+
+/**
+ * Decrypt an encrypted string back to plaintext.
+ * Supports two formats for backward compatibility:
+ *   1. Plaintext Cashu tokens (start with "cashu") — returned as-is
+ *   2. XChaCha20-Poly1305 format: "nonce:ciphertext" (2 hex parts)
+ *
+ * @param encryptedString The encrypted (or plaintext) token string
+ * @returns The original plaintext string
+ */
+export function decrypt(encryptedString: string): string {
+  // Backward compat: plaintext Cashu tokens that were never encrypted
+  if (encryptedString.startsWith('cashu')) {
+    return encryptedString;
+  }
+
+  const parts = encryptedString.split(':');
+
+  // XChaCha20-Poly1305 format: nonce:ciphertext
+  if (parts.length === 2) {
+    const [nonceHex, ciphertextHex] = parts;
+    const key = getEncryptionKey();
+    const nonce = hexToBytes(nonceHex);
+    const ciphertext = hexToBytes(ciphertextHex);
+    const cipher = xchacha20poly1305(key, nonce);
+    const plaintext = cipher.decrypt(ciphertext);
+
+    return new TextDecoder().decode(plaintext);
+  }
+
+  throw new Error('Invalid encrypted token format. Expected "nonce:ciphertext".');
+}

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
+import { decrypt } from '../lib/encryption.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type {
   DashboardResponse,
@@ -59,7 +60,7 @@ dashboardRoutes.get('/:pubkey', async (c) => {
       price_sats: number;
     }>;
 
-    const tokens = tokenRows.map((r) => r.seller_token);
+    const tokens = tokenRows.map((r) => decrypt(r.seller_token));
     const totalSats = tokenRows.reduce((sum, r) => sum + r.price_sats, 0);
 
     return c.json<APIResponse<DashboardResponse>>({

--- a/server/src/routes/earnings.ts
+++ b/server/src/routes/earnings.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
+import { decrypt } from '../lib/encryption.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type { EarningsResponse, APIResponse } from '../../../shared/types.js';
 
@@ -20,7 +21,7 @@ earningsRoutes.get('/:pubkey', async (c) => {
 
     const results = stmt.all(pubkey) as Array<{ seller_token: string; price_sats: number }>;
 
-    const tokens = results.map((r) => r.seller_token);
+    const tokens = results.map((r) => decrypt(r.seller_token));
     const totalSats = results.reduce((sum, r) => sum + r.price_sats, 0);
 
     return c.json<APIResponse<EarningsResponse>>({

--- a/server/src/routes/withdraw.ts
+++ b/server/src/routes/withdraw.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
 import { getMeltQuote, meltToLightning } from '../lib/cashu.js';
+import { decrypt } from '../lib/encryption.js';
 import { resolveAddress } from '../lib/lnaddress.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type {
@@ -107,7 +108,7 @@ withdrawRoutes.post('/execute', async (c) => {
       );
     }
 
-    const tokens = tokenRows.map((r) => r.seller_token);
+    const tokens = tokenRows.map((r) => decrypt(r.seller_token));
     const paymentIds = tokenRows.map((r) => r.payment_id);
     const totalSats = tokenRows.reduce((sum, r) => sum + r.price_sats, 0);
 


### PR DESCRIPTION
Fixes #8 
Encrypt seller tokens with ```XChaCha20-Poly1305``` using ```@noble/ciphers```. Backward-compatible with existing data. Server requires valid TOKEN_ENCRYPTION_KEY to start.