### PR TITLE
feat: add claim token for re-download without re-paying

### DIFF
--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -42,6 +42,19 @@ export function UnlockPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, unlock.loadStash]);
 
+  // After stash loads, try to recover a previous payment via claim token
+  const claimAttempted = useRef(false);
+  useEffect(() => {
+    claimAttempted.current = false;
+  }, [id]);
+  useEffect(() => {
+    if ((unlock.status === 'ready' || unlock.status === 'claiming') && !claimAttempted.current) {
+      claimAttempted.current = true;
+      unlock.tryClaimToken();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unlock.status, unlock.tryClaimToken]);
+
   // Cleanup polling and timer on unmount
   useEffect(() => {
     return () => {
@@ -51,8 +64,7 @@ export function UnlockPage() {
   }, []);
 
   const handleLnUnlock = useCallback(
-    (data: { secretKey: string; blobUrl: string; fileName?: string }) => {
-      // Use the unlock hook's internal mechanism to handle decryption
+    (data: { secretKey: string; blobUrl: string; fileName?: string; claimToken?: string }) => {
       unlock.submitLightningResult(data);
     },
     [unlock]
@@ -103,6 +115,7 @@ export function UnlockPage() {
               secretKey: status.secretKey,
               blobUrl: status.blobUrl,
               fileName: status.fileName,
+              claimToken: status.claimToken,
             });
           }
         } catch (err) {
@@ -138,7 +151,14 @@ export function UnlockPage() {
 
   // Auto-create or resume invoice when Lightning tab is active and stash is loaded
   useEffect(() => {
-    if (tab !== 'lightning' || !unlock.stash || invoice || lnLoading || unlock.status !== 'ready') {
+    if (
+      tab !== 'lightning' ||
+      !unlock.stash ||
+      invoice ||
+      lnLoading ||
+      unlock.status !== 'ready' ||
+      !claimAttempted.current
+    ) {
       return;
     }
 
@@ -223,6 +243,22 @@ export function UnlockPage() {
             <Squirrel className="w-8 h-8 text-amber-400" />
           </div>
           <p className="text-slate-400">Loading stash...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Checking previous payment via claim token (covers both the API call and file decryption)
+  if (unlock.status === 'claiming' || (unlock.status === 'decrypting' && !invoice && !token)) {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 mx-auto mb-4 bg-amber-500/20 rounded-2xl flex items-center justify-center animate-pulse">
+            <Loader2 className="w-8 h-8 text-amber-400 animate-spin" />
+          </div>
+          <p className="text-slate-400">
+            {unlock.status === 'claiming' ? 'Checking previous payment...' : 'Decrypting file...'}
+          </p>
         </div>
       </div>
     );

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -74,6 +74,22 @@ export async function unlockStash(id: string, token: string): Promise<UnlockResp
   return result.data;
 }
 
+/**
+ * Re-fetch unlock data using a claim token (no re-payment needed)
+ */
+export async function claimStash(stashId: string, claimToken: string): Promise<UnlockResponse> {
+  const response = await fetch(
+    `${API_BASE}/unlock/${stashId}/claim?token=${encodeURIComponent(claimToken)}`
+  );
+  const result: APIResponse<UnlockResponse> = await response.json();
+  if (!result.success) {
+    const err = new Error(result.error) as Error & { status: number };
+    err.status = response.status;
+    throw err;
+  }
+  return result.data;
+}
+
 export async function getDashboard(pubkey: string): Promise<DashboardResponse> {
   const url = `${API_BASE}/dashboard/${pubkey}`;
   const response = await fetch(url, {

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -1,10 +1,17 @@
 import { useState, useCallback } from 'react';
-import { getStashInfo, unlockStash } from './api';
+import { getStashInfo, unlockStash, claimStash } from './api';
 import { decryptFile, fromBase64 } from './crypto';
 import { fetchFromBlossom } from './blossom';
 import type { StashPublicInfo } from '../../../shared/types';
 
-export type UnlockStatus = 'loading' | 'ready' | 'unlocking' | 'decrypting' | 'done' | 'error';
+export type UnlockStatus =
+  | 'loading'
+  | 'claiming'
+  | 'ready'
+  | 'unlocking'
+  | 'decrypting'
+  | 'done'
+  | 'error';
 
 export interface UnlockState {
   status: UnlockStatus;
@@ -23,11 +30,37 @@ export function useUnlock(stashId: string) {
     fileName: null,
   });
 
+  const decryptAndFinish = useCallback(
+    async (data: { secretKey: string; blobUrl: string; fileName?: string }) => {
+      setState((s) => ({ ...s, status: 'decrypting', error: null }));
+
+      const ciphertext = await fetchFromBlossom(data.blobUrl);
+
+      const [nonceB64, keyB64] = data.secretKey.split(':');
+      if (!nonceB64 || !keyB64) {
+        throw new Error('Invalid secret key format');
+      }
+      const nonce = fromBase64(nonceB64);
+      const key = fromBase64(keyB64);
+
+      const plaintext = await decryptFile(ciphertext, key, nonce);
+
+      const blob = new Blob([plaintext]);
+      const downloadUrl = URL.createObjectURL(blob);
+      const fileName = data.fileName || state.stash?.title || 'download';
+
+      setState((s) => ({ ...s, status: 'done', downloadUrl, fileName }));
+    },
+    [state.stash]
+  );
+
   const loadStash = useCallback(async () => {
     try {
       setState((s) => ({ ...s, status: 'loading', error: null }));
       const stash = await getStashInfo(stashId);
-      setState((s) => ({ ...s, status: 'ready', stash }));
+      // If a claim token exists, go straight to 'claiming' to avoid flashing payment UI
+      const hasClaimToken = !!localStorage.getItem(`stashu-claim-${stashId}`);
+      setState((s) => ({ ...s, status: hasClaimToken ? 'claiming' : 'ready', stash }));
     } catch (error) {
       setState((s) => ({
         ...s,
@@ -37,6 +70,27 @@ export function useUnlock(stashId: string) {
     }
   }, [stashId]);
 
+  const tryClaimToken = useCallback(async (): Promise<boolean> => {
+    const claimToken = localStorage.getItem(`stashu-claim-${stashId}`);
+    if (!claimToken) return false;
+
+    try {
+      setState((s) => ({ ...s, status: 'claiming', error: null }));
+      const result = await claimStash(stashId, claimToken);
+      await decryptAndFinish(result);
+      return true;
+    } catch (error) {
+      const status = (error as Error & { status?: number }).status;
+      if (status === 404 || status === 410) {
+        // Token is invalid or expired — remove it permanently
+        localStorage.removeItem(`stashu-claim-${stashId}`);
+      }
+      // For transient errors (network, 500), keep the token for next attempt
+      setState((s) => ({ ...s, status: 'ready' }));
+      return false;
+    }
+  }, [stashId, decryptAndFinish]);
+
   const submitToken = useCallback(
     async (token: string) => {
       if (!token.trim()) {
@@ -45,45 +99,24 @@ export function useUnlock(stashId: string) {
       }
 
       try {
-        // Step 1: Unlock with token
         setState((s) => ({ ...s, status: 'unlocking', error: null }));
         const unlockResult = await unlockStash(stashId, token);
 
-        // Step 2: Fetch encrypted file from Blossom
-        setState((s) => ({ ...s, status: 'decrypting' }));
-        const ciphertext = await fetchFromBlossom(unlockResult.blobUrl);
-
-        // Step 3: Parse secret key (format: base64Nonce:base64Key)
-        const [nonceB64, keyB64] = unlockResult.secretKey.split(':');
-        if (!nonceB64 || !keyB64) {
-          throw new Error('Invalid secret key format');
+        // Store claim token for re-download
+        if (unlockResult.claimToken) {
+          localStorage.setItem(`stashu-claim-${stashId}`, unlockResult.claimToken);
         }
-        const nonce = fromBase64(nonceB64);
-        const key = fromBase64(keyB64);
 
-        // Step 4: Decrypt the file
-        const plaintext = await decryptFile(ciphertext, key, nonce);
-
-        // Step 5: Create download URL
-        const blob = new Blob([plaintext]);
-        const downloadUrl = URL.createObjectURL(blob);
-        const fileName = unlockResult.fileName || state.stash?.title || 'download';
-
-        setState((s) => ({
-          ...s,
-          status: 'done',
-          downloadUrl,
-          fileName,
-        }));
+        await decryptAndFinish(unlockResult);
       } catch (error) {
         setState((s) => ({
           ...s,
-          status: 'ready', // Go back to ready state so user can retry
+          status: 'ready',
           error: error instanceof Error ? error.message : 'Unlock failed',
         }));
       }
     },
-    [stashId, state.stash]
+    [stashId, decryptAndFinish]
   );
 
   const download = useCallback(() => {
@@ -102,35 +135,19 @@ export function useUnlock(stashId: string) {
    * Receives secretKey + blobUrl directly from the server polling response.
    */
   const submitLightningResult = useCallback(
-    async (data: { secretKey: string; blobUrl: string; fileName?: string }) => {
+    async (data: {
+      secretKey: string;
+      blobUrl: string;
+      fileName?: string;
+      claimToken?: string;
+    }) => {
       try {
-        setState((s) => ({ ...s, status: 'decrypting', error: null }));
-
-        // Fetch encrypted file from Blossom
-        const ciphertext = await fetchFromBlossom(data.blobUrl);
-
-        // Parse secret key (format: base64Nonce:base64Key)
-        const [nonceB64, keyB64] = data.secretKey.split(':');
-        if (!nonceB64 || !keyB64) {
-          throw new Error('Invalid secret key format');
+        // Store claim token for re-download
+        if (data.claimToken) {
+          localStorage.setItem(`stashu-claim-${stashId}`, data.claimToken);
         }
-        const nonce = fromBase64(nonceB64);
-        const key = fromBase64(keyB64);
 
-        // Decrypt the file
-        const plaintext = await decryptFile(ciphertext, key, nonce);
-
-        // Create download URL
-        const blob = new Blob([plaintext]);
-        const downloadUrl = URL.createObjectURL(blob);
-        const fileName = data.fileName || state.stash?.title || 'download';
-
-        setState((s) => ({
-          ...s,
-          status: 'done',
-          downloadUrl,
-          fileName,
-        }));
+        await decryptAndFinish(data);
       } catch (error) {
         setState((s) => ({
           ...s,
@@ -139,7 +156,7 @@ export function useUnlock(stashId: string) {
         }));
       }
     },
-    [state.stash]
+    [stashId, decryptAndFinish]
   );
 
   const reset = useCallback(() => {
@@ -158,6 +175,7 @@ export function useUnlock(stashId: string) {
   return {
     ...state,
     loadStash,
+    tryClaimToken,
     submitToken,
     submitLightningResult,
     download,

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsx watch --env-file=.env src/index.ts",
     "build": "tsc",
     "start": "node --env-file=.env dist/server/src/index.js",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --experimental-test-module-mocks --test src/**/*.test.ts"
   },
   "dependencies": {
     "@cashu/cashu-ts": "^3.6.1",

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -174,6 +174,21 @@ function cleanupStaleQuotes() {
   if (recovered.changes > 0) {
     console.log(`🔄 Reset ${recovered.changes} stuck processing payments to pending`);
   }
+
+  // Null out expired claim tokens (column added in migration v5)
+  try {
+    const expiredClaims = db
+      .prepare(
+        `UPDATE payments SET claim_token = NULL, claim_expires_at = NULL
+         WHERE claim_token IS NOT NULL AND claim_expires_at < ?`
+      )
+      .run(Math.floor(Date.now() / 1000));
+    if (expiredClaims.changes > 0) {
+      console.log(`🧹 Cleaned up ${expiredClaims.changes} expired claim token(s)`);
+    }
+  } catch {
+    // Column doesn't exist yet (pre-migration v5), skip
+  }
 }
 
 // Run cleanup on startup and every 5 minutes
@@ -323,6 +338,16 @@ const currentVersion = (
           }
           console.log(`🔐 Encrypted ${logs.length} LN address(es) in settlement_log.`);
         }
+      },
+    },
+    {
+      version: 5,
+      name: 'add claim token columns to payments',
+      run: () => {
+        db.exec(`ALTER TABLE payments ADD COLUMN claim_token TEXT DEFAULT NULL`);
+        db.exec(`ALTER TABLE payments ADD COLUMN claim_expires_at INTEGER DEFAULT NULL`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_payments_claim_token ON payments(claim_token)`);
+        console.log('🎫 Added claim_token and claim_expires_at columns to payments.');
       },
     },
   ];

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -31,4 +31,6 @@ export interface PaymentRow {
   claimed: number;
   created_at: number;
   paid_at: number | null;
+  claim_token: string | null;
+  claim_expires_at: number | null;
 }

--- a/server/src/middleware/ratelimit.ts
+++ b/server/src/middleware/ratelimit.ts
@@ -20,7 +20,7 @@ setInterval(() => {
       store.delete(key);
     }
   }
-}, 300_000);
+}, 300_000).unref();
 
 // Cap store size to prevent memory abuse (evict oldest entries)
 const MAX_ENTRIES = 10_000;
@@ -59,11 +59,12 @@ function normalizeRoute(path: string): string {
  * Create a rate limiter middleware
  * @param windowMs Time window in milliseconds
  * @param maxRequests Maximum requests per window
+ * @param keyPrefix Optional fixed key prefix (bypasses route normalization for isolated buckets)
  */
-export function rateLimit(windowMs: number, maxRequests: number) {
+export function rateLimit(windowMs: number, maxRequests: number, keyPrefix?: string) {
   return async (c: Context, next: Next) => {
     const ip = getClientIp(c);
-    const route = normalizeRoute(c.req.path);
+    const route = keyPrefix || normalizeRoute(c.req.path);
     const key = `${ip}:${route}`;
     const now = Date.now();
     const entry = store.get(key);

--- a/server/src/routes/claim.test.ts
+++ b/server/src/routes/claim.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for claim token generation on fresh payment success paths.
+ *
+ * These tests mock the Cashu mint functions to verify that claim tokens
+ * are generated and returned during fresh (non-idempotent) payments.
+ *
+ * Run with: npm test --workspace=server
+ */
+
+// Set env before any db-dependent imports
+if (!process.env.TOKEN_ENCRYPTION_KEY) {
+  const { randomBytes } = await import('node:crypto');
+  process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+}
+process.env.DB_PATH = ':memory:';
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+
+// Mock Cashu module before any route imports
+mock.module('../lib/cashu.js', {
+  namedExports: {
+    verifyAndSwapToken: async () => ({
+      success: true,
+      sellerToken: 'cashuMockedSellerToken',
+    }),
+    checkPaymentStatus: async () => ({ paid: true }),
+    mintAfterPayment: async () => 'cashuMintedToken',
+    createPaymentInvoice: async () => ({
+      invoice: 'lnbc1mock',
+      quoteId: 'mock-quote',
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
+    }),
+    getWallet: async () => ({}),
+    getTokenValue: () => 100,
+    getMeltQuote: async () => ({ success: true }),
+    meltWithRecovery: async () => ({}),
+    checkMeltQuoteStatus: async () => ({}),
+  },
+});
+
+const db = (await import('../db/index.js')).default;
+const { encrypt } = await import('../lib/encryption.js');
+const { unlockRoutes } = await import('./unlock.js');
+const { payRoutes } = await import('./pay.js');
+
+const unlockApp = new Hono();
+unlockApp.route('/api/unlock', unlockRoutes);
+
+const payApp = new Hono();
+payApp.route('/api/pay', payRoutes);
+
+const TEST_STASH = {
+  id: 'stash-claim-fresh-001',
+  blobUrl: 'https://blossom.example.com/encrypted-blob',
+  secretKey: 'claim-test-secret-key',
+  fileName: 'secret.pdf',
+  priceSats: 100,
+  sellerPubkey: 'seller-pubkey-abc',
+};
+
+function insertStash(id = TEST_STASH.id) {
+  db.prepare(
+    `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    TEST_STASH.blobUrl,
+    encrypt(TEST_STASH.secretKey),
+    TEST_STASH.sellerPubkey,
+    TEST_STASH.priceSats,
+    encrypt('Test Stash'),
+    encrypt(TEST_STASH.fileName),
+    1024
+  );
+}
+
+beforeEach(() => {
+  db.exec('DELETE FROM payments');
+  db.exec('DELETE FROM stashes');
+});
+
+describe('Fresh Cashu payment returns claimToken', () => {
+  it('includes claimToken in response after successful swap', async () => {
+    insertStash();
+
+    const res = await unlockApp.request(`/api/unlock/${TEST_STASH.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'cashuFreshToken123' }),
+    });
+
+    assert.equal(res.status, 200);
+    const { success, data } = await res.json();
+    assert.equal(success, true);
+    assert.equal(data.secretKey, TEST_STASH.secretKey);
+    assert.equal(data.blobUrl, TEST_STASH.blobUrl);
+    assert.equal(data.fileName, TEST_STASH.fileName);
+    assert.ok(data.claimToken, 'should return a claimToken');
+    assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
+
+    // Verify claim token is persisted in DB
+    const payment = db
+      .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE stash_id = ?')
+      .get(TEST_STASH.id) as { claim_token: string; claim_expires_at: number };
+    assert.equal(payment.claim_token, data.claimToken);
+    assert.ok(
+      payment.claim_expires_at > Math.floor(Date.now() / 1000),
+      'claim_expires_at should be in the future'
+    );
+  });
+});
+
+describe('Fresh Lightning payment returns claimToken', () => {
+  it('includes claimToken in response after successful mint and swap', async () => {
+    insertStash();
+
+    // Insert a pending Lightning payment (simulates invoice creation)
+    const quoteId = 'test-ln-quote';
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash) VALUES (?, ?, 'pending', ?)`
+    ).run(`ln-${quoteId}`, TEST_STASH.id, quoteId);
+
+    // Poll the status — should trigger mint + swap + return claimToken
+    const res = await payApp.request(`/api/pay/${TEST_STASH.id}/status/${quoteId}`);
+
+    assert.equal(res.status, 200);
+    const { success, data } = await res.json();
+    assert.equal(success, true);
+    assert.equal(data.paid, true);
+    assert.equal(data.secretKey, TEST_STASH.secretKey);
+    assert.ok(data.claimToken, 'should return a claimToken');
+    assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
+
+    // Verify claim token is persisted in DB
+    const payment = db
+      .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
+      .get(`ln-${quoteId}`) as { claim_token: string; claim_expires_at: number };
+    assert.equal(payment.claim_token, data.claimToken);
+    assert.ok(
+      payment.claim_expires_at > Math.floor(Date.now() / 1000),
+      'claim_expires_at should be in the future'
+    );
+  });
+});

--- a/server/src/routes/pay.test.ts
+++ b/server/src/routes/pay.test.ts
@@ -77,7 +77,7 @@ describe('GET /api/pay/:id/status/:quoteId', () => {
     assert.match((await res.json()).error, /does not match/i);
   });
 
-  it('returns unlock data when already paid', async () => {
+  it('returns unlock data with claimToken when already paid', async () => {
     insertStash();
     db.prepare(
       `INSERT INTO payments (id, stash_id, status, token_hash, seller_token, paid_at)
@@ -97,5 +97,7 @@ describe('GET /api/pay/:id/status/:quoteId', () => {
     assert.equal(data.secretKey, 'pay-secret-key');
     assert.equal(data.blobUrl, 'https://blossom.example.com/blob');
     assert.equal(data.fileName, 'file.pdf');
+    assert.ok(data.claimToken, 'should return a claimToken');
+    assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
   });
 });

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { randomBytes } from 'crypto';
 import db from '../db/index.js';
 import {
   createPaymentInvoice,
@@ -82,6 +83,23 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
         .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
 
+      // Regenerate claim token if missing or expired
+      let claimToken = existingPayment.claim_token;
+      const now = Math.floor(Date.now() / 1000);
+      if (
+        !claimToken ||
+        !existingPayment.claim_expires_at ||
+        existingPayment.claim_expires_at < now
+      ) {
+        claimToken = randomBytes(32).toString('hex');
+        const claimExpiresAt = now + 3600;
+        db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
+          claimToken,
+          claimExpiresAt,
+          paymentId
+        );
+      }
+
       return c.json<APIResponse<PayStatusResponse>>({
         success: true,
         data: {
@@ -89,6 +107,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           secretKey: decrypt(stash.secret_key),
           blobUrl: stash.blob_url,
           fileName: decrypt(stash.file_name),
+          claimToken,
         },
       });
     }
@@ -119,6 +138,23 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         const stash = db
           .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
           .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
+
+        // Read claim token from the now-paid row
+        const paidRow = db
+          .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
+          .get(paymentId) as Pick<PaymentRow, 'claim_token' | 'claim_expires_at'>;
+        let claimToken = paidRow?.claim_token ?? null;
+        const now = Math.floor(Date.now() / 1000);
+        if (!claimToken || !paidRow?.claim_expires_at || paidRow.claim_expires_at < now) {
+          claimToken = randomBytes(32).toString('hex');
+          const claimExpiresAt = now + 3600;
+          db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
+            claimToken,
+            claimExpiresAt,
+            paymentId
+          );
+        }
+
         return c.json<APIResponse<PayStatusResponse>>({
           success: true,
           data: {
@@ -126,6 +162,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
             secretKey: decrypt(stash.secret_key),
             blobUrl: stash.blob_url,
             fileName: decrypt(stash.file_name),
+            claimToken,
           },
         });
       }
@@ -184,9 +221,12 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         );
       }
 
+      const claimToken = randomBytes(32).toString('hex');
+      const claimExpiresAt = Math.floor(Date.now() / 1000) + 3600; // 1hr
+
       db.prepare(
-        `UPDATE payments SET status = 'paid', seller_token = ?, paid_at = unixepoch() WHERE id = ?`
-      ).run(encrypt(swapResult.sellerToken), paymentId);
+        `UPDATE payments SET status = 'paid', seller_token = ?, claim_token = ?, claim_expires_at = ?, paid_at = unixepoch() WHERE id = ?`
+      ).run(encrypt(swapResult.sellerToken), claimToken, claimExpiresAt, paymentId);
 
       // Trigger auto-settlement check (fire-and-forget)
       tryAutoSettle(stash.seller_pubkey).catch((err) =>
@@ -200,6 +240,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           secretKey: decrypt(stash.secret_key),
           blobUrl: stash.blob_url,
           fileName: decrypt(stash.file_name),
+          claimToken,
         },
       });
     } catch (mintError) {

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -12,6 +12,24 @@ import type { PayInvoiceResponse, PayStatusResponse, APIResponse } from '../../.
 import type { StashRow, PaymentRow } from '../db/types.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 
+function ensureClaimToken(
+  payment: Pick<PaymentRow, 'claim_token' | 'claim_expires_at'>,
+  paymentId: string
+): string {
+  const now = Math.floor(Date.now() / 1000);
+  if (payment.claim_token && payment.claim_expires_at && payment.claim_expires_at >= now) {
+    return payment.claim_token;
+  }
+  const claimToken = randomBytes(32).toString('hex');
+  const claimExpiresAt = now + 3600;
+  db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
+    claimToken,
+    claimExpiresAt,
+    paymentId
+  );
+  return claimToken;
+}
+
 export const payRoutes = new Hono();
 
 // POST /api/pay/:id/invoice — Create a Lightning invoice for a stash
@@ -83,22 +101,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
         .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
 
-      // Regenerate claim token if missing or expired
-      let claimToken = existingPayment.claim_token;
-      const now = Math.floor(Date.now() / 1000);
-      if (
-        !claimToken ||
-        !existingPayment.claim_expires_at ||
-        existingPayment.claim_expires_at < now
-      ) {
-        claimToken = randomBytes(32).toString('hex');
-        const claimExpiresAt = now + 3600;
-        db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
-          claimToken,
-          claimExpiresAt,
-          paymentId
-        );
-      }
+      const claimToken = ensureClaimToken(existingPayment, paymentId);
 
       return c.json<APIResponse<PayStatusResponse>>({
         success: true,
@@ -139,21 +142,13 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
           .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
 
-        // Read claim token from the now-paid row
         const paidRow = db
           .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
           .get(paymentId) as Pick<PaymentRow, 'claim_token' | 'claim_expires_at'>;
-        let claimToken = paidRow?.claim_token ?? null;
-        const now = Math.floor(Date.now() / 1000);
-        if (!claimToken || !paidRow?.claim_expires_at || paidRow.claim_expires_at < now) {
-          claimToken = randomBytes(32).toString('hex');
-          const claimExpiresAt = now + 3600;
-          db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
-            claimToken,
-            claimExpiresAt,
-            paymentId
-          );
-        }
+        const claimToken = ensureClaimToken(
+          paidRow ?? { claim_token: null, claim_expires_at: null },
+          paymentId
+        );
 
         return c.json<APIResponse<PayStatusResponse>>({
           success: true,

--- a/server/src/routes/unlock.test.ts
+++ b/server/src/routes/unlock.test.ts
@@ -90,7 +90,7 @@ describe('POST /api/unlock/:id', () => {
     assert.equal(res.status, 404);
   });
 
-  it('returns unlock data for already-paid token (idempotent)', async () => {
+  it('returns unlock data with claimToken for already-paid token (idempotent)', async () => {
     insertStash();
     insertPayment(TEST_STASH.id, 'cashuPaidToken', 'paid', 'cashuSellerToken');
 
@@ -104,6 +104,8 @@ describe('POST /api/unlock/:id', () => {
     assert.equal(data.secretKey, TEST_STASH.secretKey);
     assert.equal(data.blobUrl, TEST_STASH.blobUrl);
     assert.equal(data.fileName, TEST_STASH.fileName);
+    assert.ok(data.claimToken, 'should return a claimToken');
+    assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
   });
 
   it('returns 409 for pending payment', async () => {
@@ -129,5 +131,74 @@ describe('POST /api/unlock/:id', () => {
     });
     assert.equal(res.status, 400);
     assert.match((await res.json()).error, /failed/i);
+  });
+});
+
+describe('GET /api/unlock/:id/claim', () => {
+  function insertPaidPaymentWithClaim(stashId: string, claimToken: string, claimExpiresAt: number) {
+    db.prepare(
+      `INSERT INTO payments (id, stash_id, status, token_hash, seller_token, claim_token, claim_expires_at, paid_at)
+       VALUES (?, ?, 'paid', ?, ?, ?, ?, ?)`
+    ).run(
+      `${stashId}-claim-test`,
+      stashId,
+      'claim-hash',
+      encrypt('cashuSellerToken'),
+      claimToken,
+      claimExpiresAt,
+      Math.floor(Date.now() / 1000)
+    );
+  }
+
+  it('returns unlock data for valid claim token', async () => {
+    insertStash();
+    const claimToken = 'a'.repeat(64);
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    insertPaidPaymentWithClaim(TEST_STASH.id, claimToken, expiresAt);
+
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}/claim?token=${claimToken}`);
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+    assert.equal(data.secretKey, TEST_STASH.secretKey);
+    assert.equal(data.blobUrl, TEST_STASH.blobUrl);
+    assert.equal(data.fileName, TEST_STASH.fileName);
+  });
+
+  it('returns 400 when token query param is missing', async () => {
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}/claim`);
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 404 for invalid claim token', async () => {
+    insertStash();
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}/claim?token=${'b'.repeat(64)}`);
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 410 for expired claim token', async () => {
+    insertStash();
+    const claimToken = 'c'.repeat(64);
+    const expiredAt = Math.floor(Date.now() / 1000) - 100; // expired 100s ago
+    insertPaidPaymentWithClaim(TEST_STASH.id, claimToken, expiredAt);
+
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}/claim?token=${claimToken}`);
+    assert.equal(res.status, 410);
+    assert.match((await res.json()).error, /expired/i);
+  });
+
+  it('returns 404 when claim token belongs to a different stash', async () => {
+    insertStash();
+    insertStash('other-stash');
+    const claimToken = 'd'.repeat(64);
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    insertPaidPaymentWithClaim('other-stash', claimToken, expiresAt);
+
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}/claim?token=${claimToken}`);
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 404 for non-existent stash', async () => {
+    const res = await app.request(`/api/unlock/nonexistent/claim?token=${'e'.repeat(64)}`);
+    assert.equal(res.status, 404);
   });
 });

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import db from '../db/index.js';
 import { verifyAndSwapToken } from '../lib/cashu.js';
 import { encrypt, decrypt } from '../lib/encryption.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
+import { rateLimit } from '../middleware/ratelimit.js';
 import type { UnlockRequest, UnlockResponse, APIResponse } from '../../../shared/types.js';
 import type { StashRow, PaymentRow } from '../db/types.js';
 
@@ -57,12 +58,29 @@ unlockRoutes.post('/:id', async (c) => {
     if (existingPayment) {
       if (existingPayment.status === 'paid') {
         // Already paid - return the key (idempotent)
+        // Regenerate claim token if missing or expired
+        let claimToken = existingPayment.claim_token;
+        const now = Math.floor(Date.now() / 1000);
+        if (
+          !claimToken ||
+          !existingPayment.claim_expires_at ||
+          existingPayment.claim_expires_at < now
+        ) {
+          claimToken = randomBytes(32).toString('hex');
+          const claimExpiresAt = now + 3600;
+          db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
+            claimToken,
+            claimExpiresAt,
+            paymentId
+          );
+        }
         return c.json<APIResponse<UnlockResponse>>({
           success: true,
           data: {
             secretKey: decrypt(stash.secret_key),
             blobUrl: stash.blob_url,
             fileName: decrypt(stash.file_name),
+            claimToken,
           },
         });
       } else if (existingPayment.status === 'pending') {
@@ -116,13 +134,16 @@ unlockRoutes.post('/:id', async (c) => {
       );
     }
 
+    const claimToken = randomBytes(32).toString('hex');
+    const claimExpiresAt = Math.floor(Date.now() / 1000) + 3600; // 1hr
+
     db.prepare(
       `
-      UPDATE payments 
-      SET status = 'paid', seller_token = ?, paid_at = unixepoch()
+      UPDATE payments
+      SET status = 'paid', seller_token = ?, claim_token = ?, claim_expires_at = ?, paid_at = unixepoch()
       WHERE id = ?
     `
-    ).run(encrypt(swapResult.sellerToken), paymentId);
+    ).run(encrypt(swapResult.sellerToken), claimToken, claimExpiresAt, paymentId);
 
     // Trigger auto-settlement check (fire-and-forget)
     tryAutoSettle(stash.seller_pubkey).catch((err) =>
@@ -136,6 +157,7 @@ unlockRoutes.post('/:id', async (c) => {
         secretKey: decrypt(stash.secret_key),
         blobUrl: stash.blob_url,
         fileName: decrypt(stash.file_name),
+        claimToken,
       },
     });
   } catch (error) {
@@ -148,4 +170,45 @@ unlockRoutes.post('/:id', async (c) => {
       500
     );
   }
+});
+
+// GET /api/unlock/:id/claim?token=xxx - Re-download with a claim token
+unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async (c) => {
+  const stashId = c.req.param('id');
+  const claimToken = c.req.query('token');
+
+  if (!claimToken) {
+    return c.json<APIResponse<never>>({ success: false, error: 'Missing claim token' }, 400);
+  }
+
+  const payment = db
+    .prepare(
+      `SELECT claim_expires_at FROM payments WHERE stash_id = ? AND claim_token = ? AND status = 'paid'`
+    )
+    .get(stashId, claimToken) as Pick<PaymentRow, 'claim_expires_at'> | null;
+
+  if (!payment) {
+    return c.json<APIResponse<never>>({ success: false, error: 'Invalid claim token' }, 404);
+  }
+
+  if (!payment.claim_expires_at || payment.claim_expires_at < Math.floor(Date.now() / 1000)) {
+    return c.json<APIResponse<never>>({ success: false, error: 'Claim token has expired' }, 410);
+  }
+
+  const stash = db
+    .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
+    .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'> | null;
+
+  if (!stash) {
+    return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
+  }
+
+  return c.json<APIResponse<UnlockResponse>>({
+    success: true,
+    data: {
+      secretKey: decrypt(stash.secret_key),
+      blobUrl: stash.blob_url,
+      fileName: decrypt(stash.file_name),
+    },
+  });
 });

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -177,8 +177,11 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
   const stashId = c.req.param('id');
   const claimToken = c.req.query('token');
 
-  if (!claimToken) {
-    return c.json<APIResponse<never>>({ success: false, error: 'Missing claim token' }, 400);
+  if (!claimToken || !/^[0-9a-f]{64}$/.test(claimToken)) {
+    return c.json<APIResponse<never>>(
+      { success: false, error: 'Missing or invalid claim token' },
+      400
+    );
   }
 
   const payment = db

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -81,6 +81,7 @@ export interface UnlockResponse {
   secretKey: string;
   blobUrl: string;
   fileName: string;
+  claimToken?: string;
 }
 
 // GET /api/earnings (for seller dashboard)
@@ -143,6 +144,7 @@ export interface PayStatusResponse {
   secretKey?: string;
   blobUrl?: string;
   fileName?: string;
+  claimToken?: string;
 }
 
 // POST /api/withdraw/resolve-address


### PR DESCRIPTION
Fixes #31 

Adds a claim token so buyers can re-download if they close the tab after paying. Token is stored in localStorage, expires after 1 hour. New claim endpoint on the server side with rate limiting. Also added tests and a db migration for the new columns.


