### PR TITLE
feat: add blossom server selection, BUD-04 mirroring, and download fallback

### DIFF
--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -13,15 +13,27 @@ import {
   Loader2,
   Save,
   Lightbulb,
+  Server,
 } from 'lucide-react';
 import { hasIdentity, getOrCreateIdentity, getPublicKeyHex, clearIdentity } from '../lib/identity';
 import { getSettings, saveSettings } from '../lib/api';
+import {
+  getBlossomServer,
+  setBlossomServer,
+  validateBlossomUrl,
+  PRESET_BLOSSOM_SERVERS,
+  getMirroringEnabled,
+  setMirroringEnabled,
+} from '../lib/blossom';
 import { useToast } from './useToast';
 import { copyToClipboard } from '../lib/clipboard';
+
+type SettingsTab = 'payments' | 'account' | 'advanced';
 
 export function SettingsPage() {
   const navigate = useNavigate();
   const toast = useToast();
+  const [activeTab, setActiveTab] = useState<SettingsTab>('payments');
   const [nsecRevealed, setNsecRevealed] = useState(false);
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
@@ -34,6 +46,20 @@ export function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [loadingSettings, setLoadingSettings] = useState(true);
   const [settingsChanged, setSettingsChanged] = useState(false);
+
+  // Blossom server state
+  const [blossomServer, setBlossomServerState] = useState(getBlossomServer());
+  const [customBlossomUrl, setCustomBlossomUrl] = useState('');
+  const [blossomUrlError, setBlossomUrlError] = useState('');
+  const [mirroringEnabled, setMirroringEnabledState] = useState(getMirroringEnabled());
+
+  const isCustomServer = !PRESET_BLOSSOM_SERVERS.some((s) => s.url === blossomServer);
+
+  useEffect(() => {
+    if (isCustomServer) {
+      setCustomBlossomUrl(blossomServer);
+    }
+  }, [blossomServer, isCustomServer]);
 
   useEffect(() => {
     if (hasIdentity()) {
@@ -112,8 +138,44 @@ export function SettingsPage() {
     }
   };
 
+  const handleSelectBlossomPreset = (url: string) => {
+    setBlossomServer(url);
+    setBlossomServerState(url);
+    setCustomBlossomUrl('');
+    setBlossomUrlError('');
+    toast.showToast('Blossom server updated', 'success');
+  };
+
+  const handleCustomBlossomSubmit = () => {
+    if (!customBlossomUrl.trim()) return;
+    let url = customBlossomUrl.trim();
+    if (!/^https?:\/\//i.test(url)) url = `https://${url}`;
+    const result = validateBlossomUrl(url);
+    if (!result.valid) {
+      setBlossomUrlError(result.error || 'Invalid URL');
+      return;
+    }
+    const normalized = url.replace(/\/+$/, '');
+    // If it matches a preset, select that preset instead
+    const matchingPreset = PRESET_BLOSSOM_SERVERS.find((s) => s.url === normalized);
+    if (matchingPreset) {
+      handleSelectBlossomPreset(matchingPreset.url);
+      return;
+    }
+    setBlossomServer(normalized);
+    setBlossomServerState(normalized);
+    setBlossomUrlError('');
+    toast.showToast('Blossom server updated', 'success');
+  };
+
   const thresholdPresets = [100, 500, 1000, 5000, 10000];
   const isAutoSettleActive = savedLnAddress.trim() !== '' && savedThreshold > 0;
+
+  const tabs: { id: SettingsTab; label: string }[] = [
+    { id: 'payments', label: 'Payments' },
+    { id: 'account', label: 'Account' },
+    { id: 'advanced', label: 'Advanced' },
+  ];
 
   return (
     <div className="min-h-screen py-12 px-6">
@@ -134,249 +196,388 @@ export function SettingsPage() {
           </div>
         </div>
 
-        {/* Auto-Settlement */}
-        <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-          <div className="flex items-center gap-2 mb-2">
-            <Zap className="w-5 h-5 text-amber-400" />
-            <h2 className="text-lg font-semibold text-white">Auto-Settlement</h2>
-            {isAutoSettleActive ? (
-              <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
-                Active
-              </span>
-            ) : (
-              <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-400 border border-slate-700/50">
-                Disabled
-              </span>
-            )}
-          </div>
-          <p className="text-slate-400 text-sm mb-5">
-            Automatically withdraw earnings to your Lightning wallet when your balance reaches the
-            threshold. Set it once, earn passively.
-          </p>
+        {/* Tabs */}
+        <div className="flex gap-1 mb-6 bg-slate-800/50 rounded-xl p-1">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex-1 py-2.5 px-4 rounded-lg text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'bg-slate-700 text-white'
+                  : 'text-slate-400 hover:text-slate-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
 
-          {loadingSettings ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+        {/* Payments Tab */}
+        {activeTab === 'payments' && (
+          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+            <div className="flex items-center gap-2 mb-2">
+              <Zap className="w-5 h-5 text-amber-400" />
+              <h2 className="text-lg font-semibold text-white">Auto-Settlement</h2>
+              {isAutoSettleActive ? (
+                <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
+                  Active
+                </span>
+              ) : (
+                <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-400 border border-slate-700/50">
+                  Disabled
+                </span>
+              )}
             </div>
-          ) : (
-            <>
-              {/* Lightning Address */}
-              <div className="mb-5">
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Lightning Address
-                </label>
-                <input
-                  type="text"
-                  value={lnAddress}
-                  onChange={(e) => {
-                    setLnAddress(e.target.value);
-                    setSettingsChanged(true);
-                  }}
-                  placeholder="you@your-wallet.com"
-                  className="w-full bg-slate-950 border border-slate-700 rounded-xl p-4 text-amber-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-amber-500"
-                />
-                <p className="text-slate-500 text-xs mt-1.5 flex items-start gap-1">
-                  <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500/60" />
-                  Use an always-online wallet (e.g. Alby, WoS, Coinos) for reliable auto-settlement.
-                  Self-custodial mobile wallets may miss payments when offline.
-                </p>
-              </div>
+            <p className="text-slate-400 text-sm mb-5">
+              Automatically withdraw earnings to your Lightning wallet when your balance reaches the
+              threshold. Set it once, earn passively.
+            </p>
 
-              {/* Threshold */}
-              <div className="mb-5">
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Auto-withdraw when balance reaches
-                </label>
-                <div className="flex items-center gap-3 mb-3">
+            {loadingSettings ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+              </div>
+            ) : (
+              <>
+                {/* Lightning Address */}
+                <div className="mb-5">
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Lightning Address
+                  </label>
                   <input
-                    type="number"
-                    value={threshold || ''}
+                    type="text"
+                    value={lnAddress}
                     onChange={(e) => {
-                      setThreshold(Math.max(0, parseInt(e.target.value) || 0));
+                      setLnAddress(e.target.value);
                       setSettingsChanged(true);
                     }}
-                    placeholder="0"
-                    min="0"
-                    className="w-32 bg-slate-950 border border-slate-700 rounded-xl p-3 text-white text-sm font-mono focus:outline-none focus:border-amber-500"
+                    placeholder="you@your-wallet.com"
+                    className="w-full bg-slate-950 border border-slate-700 rounded-xl p-4 text-amber-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-amber-500"
                   />
-                  <span className="text-slate-400 text-sm">sats</span>
+                  <p className="text-slate-500 text-xs mt-1.5 flex items-start gap-1">
+                    <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500/60" />
+                    Use an always-online wallet (e.g. Alby, WoS, Coinos) for reliable
+                    auto-settlement. Self-custodial mobile wallets may miss payments when offline.
+                  </p>
                 </div>
 
-                {/* Preset buttons */}
-                <div className="flex flex-wrap gap-2">
-                  {thresholdPresets.map((preset) => (
-                    <button
-                      key={preset}
-                      onClick={() => {
-                        setThreshold(preset);
+                {/* Threshold */}
+                <div className="mb-5">
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    Auto-withdraw when balance reaches
+                  </label>
+                  <div className="flex items-center gap-3 mb-3">
+                    <input
+                      type="number"
+                      value={threshold || ''}
+                      onChange={(e) => {
+                        setThreshold(Math.max(0, parseInt(e.target.value) || 0));
                         setSettingsChanged(true);
                       }}
-                      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                        threshold === preset
-                          ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
-                          : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
-                      }`}
-                    >
-                      {preset.toLocaleString()} sats
-                    </button>
-                  ))}
+                      placeholder="0"
+                      min="0"
+                      className="w-32 bg-slate-950 border border-slate-700 rounded-xl p-3 text-white text-sm font-mono focus:outline-none focus:border-amber-500"
+                    />
+                    <span className="text-slate-400 text-sm">sats</span>
+                  </div>
+
+                  {/* Preset buttons */}
+                  <div className="flex flex-wrap gap-2">
+                    {thresholdPresets.map((preset) => (
+                      <button
+                        key={preset}
+                        onClick={() => {
+                          setThreshold(preset);
+                          setSettingsChanged(true);
+                        }}
+                        className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                          threshold === preset
+                            ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
+                            : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                        }`}
+                      >
+                        {preset.toLocaleString()} sats
+                      </button>
+                    ))}
+                  </div>
+                  {threshold > 0 && (
+                    <p className="text-slate-500 text-xs mt-2">
+                      When balance reaches {threshold.toLocaleString()} sats, all earnings are
+                      withdrawn minus the network routing fee. If withdrawal fails (e.g. wallet
+                      offline), tokens stay safe and retry on the next payment.
+                    </p>
+                  )}
                 </div>
-                {threshold > 0 && (
+
+                {/* Save button */}
+                <button
+                  onClick={handleSaveSettings}
+                  disabled={saving || !settingsChanged}
+                  className={`flex items-center gap-2 py-2.5 px-5 rounded-xl font-semibold text-sm transition-all ${
+                    saving || !settingsChanged
+                      ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                      : 'bg-amber-500 hover:bg-amber-600 text-white'
+                  }`}
+                >
+                  {saving ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    <>
+                      <Save className="w-4 h-4" />
+                      Save Settings
+                    </>
+                  )}
+                </button>
+                {isAutoSettleActive && (
                   <p className="text-slate-500 text-xs mt-2">
-                    When balance reaches {threshold.toLocaleString()} sats, all earnings are
-                    withdrawn minus the network routing fee. If withdrawal fails (e.g. wallet
-                    offline), tokens stay safe and retry on the next payment.
+                    To disable, clear the Lightning address and save.
                   </p>
                 )}
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Account Tab */}
+        {activeTab === 'account' && (
+          <>
+            {/* Public Key */}
+            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+              <div className="flex items-center gap-2 mb-4">
+                <Shield className="w-5 h-5 text-indigo-400" />
+                <h2 className="text-lg font-semibold text-white">Public Key</h2>
+              </div>
+              <p className="text-slate-400 text-sm mb-4">
+                Your public identity on Nostr. Safe to share — this is how buyers' payments are
+                linked to you.
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-indigo-300 break-all select-all">
+                  {identity.npub}
+                </div>
+                <button
+                  onClick={() => handleCopy(identity.npub, 'Public key')}
+                  className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
+                  title="Copy public key"
+                >
+                  {copiedField === 'Public key' ? (
+                    <Check className="w-5 h-5 text-emerald-400" />
+                  ) : (
+                    <Copy className="w-5 h-5 text-slate-300" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* Recovery Token (nsec) */}
+            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+              <div className="flex items-center gap-2 mb-4">
+                <AlertTriangle className="w-5 h-5 text-amber-400" />
+                <h2 className="text-lg font-semibold text-white">Recovery Token</h2>
+              </div>
+              <p className="text-slate-400 text-sm mb-4">
+                Your secret key. <strong className="text-rose-400">Never share this.</strong> Anyone
+                with this token can access your earnings.
+              </p>
+
+              <div className="flex items-center gap-3 mb-3">
+                <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-amber-400 break-all">
+                  {nsecRevealed
+                    ? identity.nsec
+                    : '••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••'}
+                </div>
+                <button
+                  onClick={() => handleCopy(identity.nsec, 'Recovery token')}
+                  className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
+                  title="Copy recovery token"
+                >
+                  {copiedField === 'Recovery token' ? (
+                    <Check className="w-5 h-5 text-emerald-400" />
+                  ) : (
+                    <Copy className="w-5 h-5 text-slate-300" />
+                  )}
+                </button>
               </div>
 
-              {/* Save button */}
               <button
-                onClick={handleSaveSettings}
-                disabled={saving || !settingsChanged}
-                className={`flex items-center gap-2 py-2.5 px-5 rounded-xl font-semibold text-sm transition-all ${
-                  saving || !settingsChanged
-                    ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
-                    : 'bg-amber-500 hover:bg-amber-600 text-white'
-                }`}
+                onClick={() => setNsecRevealed(!nsecRevealed)}
+                className="text-sm text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1.5"
               >
-                {saving ? (
+                {nsecRevealed ? (
                   <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    Saving...
+                    <EyeOff className="w-4 h-4" />
+                    Hide token
                   </>
                 ) : (
                   <>
-                    <Save className="w-4 h-4" />
-                    Save Settings
+                    <Eye className="w-4 h-4" />
+                    Reveal token
                   </>
                 )}
               </button>
-              {isAutoSettleActive && (
-                <p className="text-slate-500 text-xs mt-2">
-                  To disable, clear the Lightning address and save.
-                </p>
-              )}
-            </>
-          )}
-        </div>
-
-        {/* Public Key */}
-        <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-          <div className="flex items-center gap-2 mb-4">
-            <Shield className="w-5 h-5 text-indigo-400" />
-            <h2 className="text-lg font-semibold text-white">Public Key</h2>
-          </div>
-          <p className="text-slate-400 text-sm mb-4">
-            Your public identity on Nostr. Safe to share — this is how buyers' payments are linked
-            to you.
-          </p>
-          <div className="flex items-center gap-3">
-            <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-indigo-300 break-all select-all">
-              {identity.npub}
             </div>
-            <button
-              onClick={() => handleCopy(identity.npub, 'Public key')}
-              className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
-              title="Copy public key"
-            >
-              {copiedField === 'Public key' ? (
-                <Check className="w-5 h-5 text-emerald-400" />
-              ) : (
-                <Copy className="w-5 h-5 text-slate-300" />
-              )}
-            </button>
-          </div>
-        </div>
 
-        {/* Recovery Token (nsec) */}
-        <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-          <div className="flex items-center gap-2 mb-4">
-            <AlertTriangle className="w-5 h-5 text-amber-400" />
-            <h2 className="text-lg font-semibold text-white">Recovery Token</h2>
-          </div>
-          <p className="text-slate-400 text-sm mb-4">
-            Your secret key. <strong className="text-rose-400">Never share this.</strong> Anyone
-            with this token can access your earnings.
-          </p>
-
-          <div className="flex items-center gap-3 mb-3">
-            <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-amber-400 break-all">
-              {nsecRevealed
-                ? identity.nsec
-                : '••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••'}
-            </div>
-            <button
-              onClick={() => handleCopy(identity.nsec, 'Recovery token')}
-              className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
-              title="Copy recovery token"
-            >
-              {copiedField === 'Recovery token' ? (
-                <Check className="w-5 h-5 text-emerald-400" />
-              ) : (
-                <Copy className="w-5 h-5 text-slate-300" />
-              )}
-            </button>
-          </div>
-
-          <button
-            onClick={() => setNsecRevealed(!nsecRevealed)}
-            className="text-sm text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1.5"
-          >
-            {nsecRevealed ? (
-              <>
-                <EyeOff className="w-4 h-4" />
-                Hide token
-              </>
-            ) : (
-              <>
-                <Eye className="w-4 h-4" />
-                Reveal token
-              </>
-            )}
-          </button>
-        </div>
-
-        {/* Danger Zone */}
-        <div className="bg-rose-500/5 border border-rose-500/20 rounded-2xl p-6">
-          <div className="flex items-center gap-2 mb-4">
-            <Trash2 className="w-5 h-5 text-rose-400" />
-            <h2 className="text-lg font-semibold text-rose-300">Danger Zone</h2>
-          </div>
-          <p className="text-slate-400 text-sm mb-4">
-            Clear your identity from this device. Make sure you've saved your recovery token first —{' '}
-            <strong className="text-rose-400">this cannot be undone</strong>.
-          </p>
-
-          {!showClearConfirm ? (
-            <button
-              onClick={() => setShowClearConfirm(true)}
-              className="py-3 px-6 bg-rose-500/10 border border-rose-500/30 text-rose-400 font-semibold rounded-xl hover:bg-rose-500/20 transition-colors"
-            >
-              Clear Identity
-            </button>
-          ) : (
-            <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4">
-              <p className="text-rose-300 text-sm font-medium mb-4">
-                Are you sure? This will remove your keys from this device.
+            {/* Danger Zone */}
+            <div className="bg-rose-500/5 border border-rose-500/20 rounded-2xl p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <Trash2 className="w-5 h-5 text-rose-400" />
+                <h2 className="text-lg font-semibold text-rose-300">Danger Zone</h2>
+              </div>
+              <p className="text-slate-400 text-sm mb-4">
+                Clear your identity from this device. Make sure you've saved your recovery token
+                first — <strong className="text-rose-400">this cannot be undone</strong>.
               </p>
-              <div className="flex gap-3">
+
+              {!showClearConfirm ? (
                 <button
-                  onClick={handleClearIdentity}
-                  className="py-2 px-5 bg-rose-500 hover:bg-rose-600 text-white font-semibold rounded-lg transition-colors"
+                  onClick={() => setShowClearConfirm(true)}
+                  className="py-3 px-6 bg-rose-500/10 border border-rose-500/30 text-rose-400 font-semibold rounded-xl hover:bg-rose-500/20 transition-colors"
                 >
-                  Yes, Clear
+                  Clear Identity
                 </button>
-                <button
-                  onClick={() => setShowClearConfirm(false)}
-                  className="py-2 px-5 bg-slate-700 hover:bg-slate-600 text-slate-300 font-semibold rounded-lg transition-colors"
-                >
-                  Cancel
-                </button>
+              ) : (
+                <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4">
+                  <p className="text-rose-300 text-sm font-medium mb-4">
+                    Are you sure? This will remove your keys from this device.
+                  </p>
+                  <div className="flex gap-3">
+                    <button
+                      onClick={handleClearIdentity}
+                      className="py-2 px-5 bg-rose-500 hover:bg-rose-600 text-white font-semibold rounded-lg transition-colors"
+                    >
+                      Yes, Clear
+                    </button>
+                    <button
+                      onClick={() => setShowClearConfirm(false)}
+                      className="py-2 px-5 bg-slate-700 hover:bg-slate-600 text-slate-300 font-semibold rounded-lg transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Advanced Tab */}
+        {activeTab === 'advanced' && (
+          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+            <div className="flex items-center gap-2 mb-2">
+              <Server className="w-5 h-5 text-cyan-400" />
+              <h2 className="text-lg font-semibold text-white">Blossom Server</h2>
+            </div>
+            <p className="text-slate-400 text-sm mb-5">
+              Choose where your encrypted files are stored. Use the toggle below to control backup
+              mirroring.
+            </p>
+
+            {/* Preset server buttons */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Select a server
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {PRESET_BLOSSOM_SERVERS.map((server) => (
+                  <button
+                    key={server.url}
+                    onClick={() => handleSelectBlossomPreset(server.url)}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                      blossomServer === server.url
+                        ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
+                        : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                    }`}
+                  >
+                    {server.label}
+                  </button>
+                ))}
               </div>
             </div>
-          )}
-        </div>
+
+            {/* Custom URL input */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Or use a custom server
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  type="text"
+                  value={customBlossomUrl}
+                  onChange={(e) => {
+                    setCustomBlossomUrl(e.target.value);
+                    setBlossomUrlError('');
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleCustomBlossomSubmit();
+                  }}
+                  onBlur={() => {
+                    if (customBlossomUrl.trim()) handleCustomBlossomSubmit();
+                  }}
+                  placeholder="your-blossom-server.com"
+                  className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-3 text-cyan-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-cyan-500"
+                />
+              </div>
+              {blossomUrlError && <p className="text-rose-400 text-xs mt-1.5">{blossomUrlError}</p>}
+              <p className="text-slate-500 text-xs mt-1.5">
+                Most public Blossom servers don't support encrypted file uploads. Only add a server
+                you've tested.
+              </p>
+            </div>
+
+            {/* Current server indicator */}
+            <div className="bg-slate-950/50 border border-slate-700/50 rounded-xl p-3 mb-4">
+              <p className="text-slate-500 text-xs">
+                Current: <span className="text-cyan-400 font-mono">{blossomServer}</span>
+              </p>
+            </div>
+
+            {/* Mirroring toggle */}
+            <div className="flex items-center justify-between py-3 border-t border-slate-700/50 mt-2 mb-3">
+              <div>
+                <p className="text-sm font-medium text-slate-300">Mirror to backup servers</p>
+                <p className="text-slate-500 text-xs mt-0.5">
+                  Copies your file to other Blossom servers so buyers can download even if your
+                  primary server is down.
+                </p>
+              </div>
+              <button
+                onClick={() => {
+                  const next = !mirroringEnabled;
+                  setMirroringEnabled(next);
+                  setMirroringEnabledState(next);
+                  toast.showToast(next ? 'Mirroring enabled' : 'Mirroring disabled', 'success');
+                }}
+                className={`relative shrink-0 ml-4 w-11 h-6 rounded-full transition-colors ${
+                  mirroringEnabled ? 'bg-cyan-500' : 'bg-slate-600'
+                }`}
+                role="switch"
+                aria-checked={mirroringEnabled}
+              >
+                <span
+                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                    mirroringEnabled ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Hints */}
+            <div className="space-y-1.5">
+              <p className="text-slate-500 text-xs flex items-start gap-1">
+                <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
+                Applies to new stashes only. Existing stashes stay on their original server.
+              </p>
+              <p className="text-slate-500 text-xs flex items-start gap-1">
+                <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
+                Your server must be publicly accessible for buyers to download files.
+              </p>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -535,35 +535,37 @@ export function SettingsPage() {
               </p>
             </div>
 
-            {/* Mirroring toggle */}
-            <div className="flex items-center justify-between py-3 border-t border-slate-700/50 mt-2 mb-3">
-              <div>
-                <p className="text-sm font-medium text-slate-300">Mirror to backup servers</p>
-                <p className="text-slate-500 text-xs mt-0.5">
-                  Copies your file to other Blossom servers so buyers can download even if your
-                  primary server is down.
-                </p>
-              </div>
-              <button
-                onClick={() => {
-                  const next = !mirroringEnabled;
-                  setMirroringEnabled(next);
-                  setMirroringEnabledState(next);
-                  toast.showToast(next ? 'Mirroring enabled' : 'Mirroring disabled', 'success');
-                }}
-                className={`relative shrink-0 ml-4 w-11 h-6 rounded-full transition-colors ${
-                  mirroringEnabled ? 'bg-cyan-500' : 'bg-slate-600'
-                }`}
-                role="switch"
-                aria-checked={mirroringEnabled}
-              >
-                <span
-                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
-                    mirroringEnabled ? 'translate-x-5' : 'translate-x-0'
+            {/* Mirroring toggle — only show when there are backup servers to mirror to */}
+            {PRESET_BLOSSOM_SERVERS.filter((s) => s.url !== blossomServer).length > 0 && (
+              <div className="flex items-center justify-between py-3 border-t border-slate-700/50 mt-2 mb-3">
+                <div>
+                  <p className="text-sm font-medium text-slate-300">Mirror to backup servers</p>
+                  <p className="text-slate-500 text-xs mt-0.5">
+                    Copies your file to other Blossom servers so buyers can download even if your
+                    primary server is down.
+                  </p>
+                </div>
+                <button
+                  onClick={() => {
+                    const next = !mirroringEnabled;
+                    setMirroringEnabled(next);
+                    setMirroringEnabledState(next);
+                    toast.showToast(next ? 'Mirroring enabled' : 'Mirroring disabled', 'success');
+                  }}
+                  className={`relative shrink-0 ml-4 w-11 h-6 rounded-full transition-colors ${
+                    mirroringEnabled ? 'bg-cyan-500' : 'bg-slate-600'
                   }`}
-                />
-              </button>
-            </div>
+                  role="switch"
+                  aria-checked={mirroringEnabled}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                      mirroringEnabled ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+            )}
 
             {/* Hints */}
             <div className="space-y-1.5">

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -64,7 +64,13 @@ export function UnlockPage() {
   }, []);
 
   const handleLnUnlock = useCallback(
-    (data: { secretKey: string; blobUrl: string; fileName?: string; claimToken?: string }) => {
+    (data: {
+      secretKey: string;
+      blobUrl: string;
+      blobSha256?: string;
+      fileName?: string;
+      claimToken?: string;
+    }) => {
       unlock.submitLightningResult(data);
     },
     [unlock]
@@ -114,6 +120,7 @@ export function UnlockPage() {
             handleLnUnlock({
               secretKey: status.secretKey,
               blobUrl: status.blobUrl,
+              blobSha256: status.blobSha256,
               fileName: status.fileName,
               claimToken: status.claimToken,
             });

--- a/client/src/lib/blossom.test.ts
+++ b/client/src/lib/blossom.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sha256 } from './crypto.js';
+
+const blossomFixtures = vi.hoisted(() => ({
+  makeUploadEvent(url: string, hash: string) {
+    return {
+      kind: 24242,
+      created_at: 1,
+      tags: [
+        ['t', 'upload'],
+        ['x', hash],
+      ],
+      content: `Upload to ${url}`,
+    };
+  },
+  makeMirrorEvent(url: string, hash: string) {
+    return {
+      kind: 24242,
+      created_at: 1,
+      tags: [
+        ['t', 'upload'],
+        ['x', hash],
+      ],
+      content: `Mirror to ${url}`,
+    };
+  },
+}));
+
+function toBase64Url(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+vi.mock('./nostr.js', () => ({
+  createBlossomAuthEvent: vi.fn((url: string, hash: string) =>
+    blossomFixtures.makeUploadEvent(url, hash)
+  ),
+  createBlossomMirrorAuthEvent: vi.fn((url: string, hash: string) =>
+    blossomFixtures.makeMirrorEvent(url, hash)
+  ),
+}));
+
+import { mirrorToBlossom, uploadToBlossom } from './blossom.js';
+
+describe('Blossom protocol client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads with Base64url auth and X-SHA-256 header', async () => {
+    const data = new TextEncoder().encode('hello blossom');
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://blossom.example.com/blob' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await uploadToBlossom(data, 'text/plain', 'https://blossom.example.com');
+
+    expect(result.sha256).toBe(sha256(data));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    const token = headers.Authorization.slice('Nostr '.length);
+    const expectedToken = toBase64Url(
+      JSON.stringify(
+        blossomFixtures.makeUploadEvent('https://blossom.example.com/upload', sha256(data))
+      )
+    );
+
+    expect(headers['Content-Type']).toBe('text/plain');
+    expect(headers['X-SHA-256']).toBe(sha256(data));
+    expect(token).toBe(expectedToken);
+    expect(token).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(token).not.toContain('=');
+  });
+
+  it('mirrors with Base64url auth', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ok = await mirrorToBlossom(
+      'c'.repeat(64),
+      'https://source.example.com/ciphertext',
+      'https://mirror.example.com'
+    );
+
+    expect(ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    const token = headers.Authorization.slice('Nostr '.length);
+    const expectedToken = toBase64Url(
+      JSON.stringify(
+        blossomFixtures.makeMirrorEvent('https://mirror.example.com/mirror', 'c'.repeat(64))
+      )
+    );
+
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(token).toBe(expectedToken);
+    expect(token).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(token).not.toContain('=');
+    expect(init.body).toBe(JSON.stringify({ url: 'https://source.example.com/ciphertext' }));
+  });
+});

--- a/client/src/lib/blossom.ts
+++ b/client/src/lib/blossom.ts
@@ -47,7 +47,7 @@ export function validateBlossomUrl(url: string): { valid: boolean; error?: strin
   if (!trimmed) return { valid: false, error: 'URL is required' };
   try {
     const parsed = new URL(trimmed);
-    if (parsed.protocol !== 'https:' && !trimmed.startsWith('http://localhost')) {
+    if (parsed.protocol !== 'https:' && parsed.hostname !== 'localhost') {
       return { valid: false, error: 'Must use HTTPS' };
     }
     return { valid: true };

--- a/client/src/lib/blossom.ts
+++ b/client/src/lib/blossom.ts
@@ -1,18 +1,70 @@
 /**
  * Blossom Protocol Integration
  * Uploads encrypted files to a Blossom server with NIP-98 authentication
+ * Supports BUD-04 mirroring for redundancy and fallback downloads
  */
 
-import { createBlossomAuthEvent } from './nostr';
+import { createBlossomAuthEvent, createBlossomMirrorAuthEvent } from './nostr';
 import { sha256 } from './crypto';
 
 const DEFAULT_BLOSSOM_SERVER = import.meta.env.VITE_BLOSSOM_URL || 'https://blossom.primal.net';
+const BLOSSOM_STORAGE_KEY = 'stashu_blossom_server';
+
+export const PRESET_BLOSSOM_SERVERS = [{ label: 'Primal', url: 'https://blossom.primal.net' }];
+
+export const MIRROR_SERVERS = PRESET_BLOSSOM_SERVERS.map((s) => s.url);
+
+const BLOSSOM_MIRRORING_KEY = 'stashu_blossom_mirroring';
+
+export function getMirroringEnabled(): boolean {
+  const stored = localStorage.getItem(BLOSSOM_MIRRORING_KEY);
+  return stored === null ? true : stored === 'true';
+}
+
+export function setMirroringEnabled(enabled: boolean): void {
+  if (enabled) {
+    localStorage.removeItem(BLOSSOM_MIRRORING_KEY);
+  } else {
+    localStorage.setItem(BLOSSOM_MIRRORING_KEY, 'false');
+  }
+}
+
+export function getBlossomServer(): string {
+  return localStorage.getItem(BLOSSOM_STORAGE_KEY) || DEFAULT_BLOSSOM_SERVER;
+}
+
+export function setBlossomServer(url: string): void {
+  const normalized = url.trim().replace(/\/+$/, '');
+  if (normalized === DEFAULT_BLOSSOM_SERVER) {
+    localStorage.removeItem(BLOSSOM_STORAGE_KEY);
+  } else {
+    localStorage.setItem(BLOSSOM_STORAGE_KEY, normalized);
+  }
+}
+
+export function validateBlossomUrl(url: string): { valid: boolean; error?: string } {
+  const trimmed = url.trim().replace(/\/+$/, '');
+  if (!trimmed) return { valid: false, error: 'URL is required' };
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'https:' && !trimmed.startsWith('http://localhost')) {
+      return { valid: false, error: 'Must use HTTPS' };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: false, error: 'Invalid URL' };
+  }
+}
 
 export interface BlossomUploadResult {
   url: string;
   sha256: string;
   size: number;
   type: string;
+}
+
+function encodeBase64Url(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
 /**
@@ -34,8 +86,8 @@ export async function uploadToBlossom(
   // Create Blossom Authorization event (kind 24242)
   const authEvent = await createBlossomAuthEvent(uploadUrl, dataHash);
 
-  // Encode auth event as base64 for Authorization header
-  const authHeader = `Nostr ${btoa(JSON.stringify(authEvent))}`;
+  // BUD-11 requires Base64url without padding in the Authorization header.
+  const authHeader = `Nostr ${encodeBase64Url(JSON.stringify(authEvent))}`;
 
   // Upload the file
   const response = await fetch(uploadUrl, {
@@ -43,6 +95,7 @@ export async function uploadToBlossom(
     headers: {
       Authorization: authHeader,
       'Content-Type': contentType,
+      'X-SHA-256': dataHash,
     },
     body: data as unknown as BodyInit,
   });
@@ -76,4 +129,82 @@ export async function fetchFromBlossom(url: string): Promise<Uint8Array> {
 
   const buffer = await response.arrayBuffer();
   return new Uint8Array(buffer);
+}
+
+/**
+ * Mirror a blob to another Blossom server (BUD-04)
+ * Fire-and-forget — returns true/false, never throws
+ */
+export async function mirrorToBlossom(
+  blobSha256: string,
+  sourceUrl: string,
+  mirrorServer: string
+): Promise<boolean> {
+  try {
+    const mirrorUrl = `${mirrorServer}/mirror`;
+    const authEvent = await createBlossomMirrorAuthEvent(mirrorUrl, blobSha256);
+    const authHeader = `Nostr ${encodeBase64Url(JSON.stringify(authEvent))}`;
+
+    const response = await fetch(mirrorUrl, {
+      method: 'PUT',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url: sourceUrl }),
+    });
+
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mirror to all backup servers except the primary (fire-and-forget)
+ * Respects the seller's mirroring preference
+ */
+export function mirrorToBackupServers(
+  blobSha256: string,
+  sourceUrl: string,
+  primaryServer: string
+): void {
+  if (!getMirroringEnabled()) return;
+  const mirrors = MIRROR_SERVERS.filter((s) => s !== primaryServer);
+  for (const server of mirrors) {
+    mirrorToBlossom(blobSha256, sourceUrl, server).then((ok) => {
+      if (ok) console.log(`Mirrored to ${server}`);
+    });
+  }
+}
+
+/**
+ * Fetch from Blossom with fallback to mirror servers using SHA256 hash
+ */
+export async function fetchFromBlossomWithFallback(
+  primaryUrl: string,
+  blobSha256: string | null | undefined
+): Promise<Uint8Array> {
+  // Try primary first
+  try {
+    return await fetchFromBlossom(primaryUrl);
+  } catch (primaryError) {
+    if (!blobSha256) throw primaryError;
+
+    // Try each mirror server
+    for (const server of MIRROR_SERVERS) {
+      try {
+        const fallbackUrl = `${server}/${blobSha256}`;
+        if (fallbackUrl === primaryUrl) continue;
+        return await fetchFromBlossom(fallbackUrl);
+      } catch {
+        continue;
+      }
+    }
+
+    throw new Error(
+      `File unavailable. Primary server and all mirrors failed. ` +
+        `The file may have been removed from storage.`
+    );
+  }
 }

--- a/client/src/lib/identity.ts
+++ b/client/src/lib/identity.ts
@@ -114,4 +114,6 @@ export function acknowledgeRecovery(): void {
 export function clearIdentity(): void {
   localStorage.removeItem(STORAGE_KEY);
   localStorage.removeItem('stashu_identity_ack');
+  localStorage.removeItem('stashu_blossom_server');
+  localStorage.removeItem('stashu_blossom_mirroring');
 }

--- a/client/src/lib/nostr.test.ts
+++ b/client/src/lib/nostr.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { createBlossomAuthEvent, createBlossomMirrorAuthEvent } from './nostr.js';
+
+describe('Blossom auth events', () => {
+  it('creates upload auth events with the upload verb and blob hash scope', () => {
+    const event = createBlossomAuthEvent('https://blossom.example.com/upload', 'a'.repeat(64));
+
+    expect(event.kind).toBe(24242);
+    expect(event.tags).toContainEqual(['t', 'upload']);
+    expect(event.tags).toContainEqual(['x', 'a'.repeat(64)]);
+  });
+
+  it('creates mirror auth events with the upload verb per BUD-11', () => {
+    const event = createBlossomMirrorAuthEvent(
+      'https://blossom.example.com/mirror',
+      'b'.repeat(64)
+    );
+
+    expect(event.kind).toBe(24242);
+    expect(event.tags).toContainEqual(['t', 'upload']);
+    expect(event.tags).toContainEqual(['x', 'b'.repeat(64)]);
+  });
+});

--- a/client/src/lib/nostr.ts
+++ b/client/src/lib/nostr.ts
@@ -29,3 +29,23 @@ export function createBlossomAuthEvent(url: string, sha256hash: string): Verifie
     content: `Upload to ${url}`,
   });
 }
+
+export function createBlossomMirrorAuthEvent(url: string, sha256hash: string): VerifiedEvent {
+  const expiration = Math.floor(Date.now() / 1000) + 300;
+  const tags: string[][] = [
+    // BUD-11 defines PUT /mirror as an `upload`-authorized action.
+    ['t', 'upload'],
+    ['expiration', String(expiration)],
+  ];
+
+  if (sha256hash) {
+    tags.push(['x', sha256hash]);
+  }
+
+  return signEvent({
+    kind: 24242,
+    created_at: Math.floor(Date.now() / 1000),
+    tags,
+    content: `Mirror to ${url}`,
+  });
+}

--- a/client/src/lib/useStash.ts
+++ b/client/src/lib/useStash.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { encryptFile, readFileAsArrayBuffer, toBase64 } from './crypto';
-import { uploadToBlossom } from './blossom';
+import { uploadToBlossom, getBlossomServer, mirrorToBackupServers } from './blossom';
 import { getPublicKey } from './nostr';
 import { createStash } from './api';
 import { hasIdentity, hasAcknowledgedRecovery } from './identity';
@@ -42,11 +42,16 @@ export function useStash() {
       const secretKey = `${toBase64(nonce)}:${toBase64(key)}`;
 
       setState((s) => ({ ...s, status: 'uploading', progress: 60 }));
-      const uploadResult = await uploadToBlossom(ciphertext, file.type);
+      const selectedServer = getBlossomServer();
+      const uploadResult = await uploadToBlossom(ciphertext, file.type, selectedServer);
+
+      // Mirror to backup servers for redundancy (fire-and-forget)
+      mirrorToBackupServers(uploadResult.sha256, uploadResult.url, selectedServer);
 
       setState((s) => ({ ...s, status: 'creating', progress: 80 }));
       const stashResult = await createStash({
         blobUrl: uploadResult.url,
+        blobSha256: uploadResult.sha256,
         secretKey,
         sellerPubkey: pubkey,
         priceSats: options.priceSats,

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { getStashInfo, unlockStash, claimStash } from './api';
 import { decryptFile, fromBase64 } from './crypto';
-import { fetchFromBlossom } from './blossom';
+import { fetchFromBlossomWithFallback } from './blossom';
 import type { StashPublicInfo } from '../../../shared/types';
 
 export type UnlockStatus =
@@ -31,10 +31,15 @@ export function useUnlock(stashId: string) {
   });
 
   const decryptAndFinish = useCallback(
-    async (data: { secretKey: string; blobUrl: string; fileName?: string }) => {
+    async (data: {
+      secretKey: string;
+      blobUrl: string;
+      blobSha256?: string;
+      fileName?: string;
+    }) => {
       setState((s) => ({ ...s, status: 'decrypting', error: null }));
 
-      const ciphertext = await fetchFromBlossom(data.blobUrl);
+      const ciphertext = await fetchFromBlossomWithFallback(data.blobUrl, data.blobSha256);
 
       const [nonceB64, keyB64] = data.secretKey.split(':');
       if (!nonceB64 || !keyB64) {
@@ -138,6 +143,7 @@ export function useUnlock(stashId: string) {
     async (data: {
       secretKey: string;
       blobUrl: string;
+      blobSha256?: string;
       fileName?: string;
       claimToken?: string;
     }) => {

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -350,6 +350,14 @@ const currentVersion = (
         console.log('🎫 Added claim_token and claim_expires_at columns to payments.');
       },
     },
+    {
+      version: 6,
+      name: 'add blob_sha256 column to stashes',
+      run: () => {
+        db.exec(`ALTER TABLE stashes ADD COLUMN blob_sha256 TEXT DEFAULT NULL`);
+        console.log('🔗 Added blob_sha256 column to stashes for BUD-04 mirroring fallback.');
+      },
+    },
   ];
 
   // Run pending migrations in a transaction

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -10,6 +10,7 @@
 export interface StashRow {
   id: string;
   blob_url: string;
+  blob_sha256: string | null;
   secret_key: string; // encrypted
   key_backup: string | null;
   seller_pubkey: string;

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -98,8 +98,8 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
     // Already processed — return the unlock data
     if (existingPayment.status === 'paid') {
       const stash = db
-        .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
-        .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
+        .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
+        .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'>;
 
       const claimToken = ensureClaimToken(existingPayment, paymentId);
 
@@ -109,6 +109,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           paid: true,
           secretKey: decrypt(stash.secret_key),
           blobUrl: stash.blob_url,
+          blobSha256: stash.blob_sha256 ?? undefined,
           fileName: decrypt(stash.file_name),
           claimToken,
         },
@@ -139,8 +140,8 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
 
       if (current?.status === 'paid') {
         const stash = db
-          .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
-          .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'>;
+          .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
+          .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'>;
 
         const paidRow = db
           .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
@@ -156,6 +157,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
             paid: true,
             secretKey: decrypt(stash.secret_key),
             blobUrl: stash.blob_url,
+            blobSha256: stash.blob_sha256 ?? undefined,
             fileName: decrypt(stash.file_name),
             claimToken,
           },
@@ -181,11 +183,17 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
 
     const stash = db
       .prepare(
-        'SELECT id, price_sats, secret_key, blob_url, file_name, seller_pubkey FROM stashes WHERE id = ?'
+        'SELECT id, price_sats, secret_key, blob_url, blob_sha256, file_name, seller_pubkey FROM stashes WHERE id = ?'
       )
       .get(stashId) as Pick<
       StashRow,
-      'id' | 'price_sats' | 'secret_key' | 'blob_url' | 'file_name' | 'seller_pubkey'
+      | 'id'
+      | 'price_sats'
+      | 'secret_key'
+      | 'blob_url'
+      | 'blob_sha256'
+      | 'file_name'
+      | 'seller_pubkey'
     > | null;
 
     if (!stash) {
@@ -234,6 +242,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           paid: true,
           secretKey: decrypt(stash.secret_key),
           blobUrl: stash.blob_url,
+          blobSha256: stash.blob_sha256 ?? undefined,
           fileName: decrypt(stash.file_name),
           claimToken,
         },

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -62,6 +62,13 @@ stashRoutes.post('/', async (c) => {
       );
     }
 
+    if (body.blobSha256 && !/^[0-9a-f]{64}$/.test(body.blobSha256)) {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'blobSha256 must be 64 lowercase hex characters' },
+        400
+      );
+    }
+
     const id = uuidv4();
 
     const stmt = db.prepare(`

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -65,13 +65,14 @@ stashRoutes.post('/', async (c) => {
     const id = uuidv4();
 
     const stmt = db.prepare(`
-      INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, description, file_name, file_size, preview_url)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO stashes (id, blob_url, blob_sha256, secret_key, seller_pubkey, price_sats, title, description, file_name, file_size, preview_url)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
       id,
       body.blobUrl,
+      body.blobSha256 || null,
       encrypt(body.secretKey),
       pubkey, // Use authed pubkey, not body.sellerPubkey (prevents spoofing)
       body.priceSats,

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -28,12 +28,18 @@ unlockRoutes.post('/:id', async (c) => {
 
     // Get stash details
     const stashStmt = db.prepare(`
-      SELECT id, blob_url, secret_key, file_name, price_sats, seller_pubkey 
+      SELECT id, blob_url, blob_sha256, secret_key, file_name, price_sats, seller_pubkey
       FROM stashes WHERE id = ?
     `);
     const stash = stashStmt.get(stashId) as Pick<
       StashRow,
-      'id' | 'blob_url' | 'secret_key' | 'file_name' | 'price_sats' | 'seller_pubkey'
+      | 'id'
+      | 'blob_url'
+      | 'blob_sha256'
+      | 'secret_key'
+      | 'file_name'
+      | 'price_sats'
+      | 'seller_pubkey'
     > | null;
 
     if (!stash) {
@@ -79,6 +85,7 @@ unlockRoutes.post('/:id', async (c) => {
           data: {
             secretKey: decrypt(stash.secret_key),
             blobUrl: stash.blob_url,
+            blobSha256: stash.blob_sha256 ?? undefined,
             fileName: decrypt(stash.file_name),
             claimToken,
           },
@@ -156,6 +163,7 @@ unlockRoutes.post('/:id', async (c) => {
       data: {
         secretKey: decrypt(stash.secret_key),
         blobUrl: stash.blob_url,
+        blobSha256: stash.blob_sha256 ?? undefined,
         fileName: decrypt(stash.file_name),
         claimToken,
       },
@@ -199,8 +207,8 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
   }
 
   const stash = db
-    .prepare('SELECT secret_key, blob_url, file_name FROM stashes WHERE id = ?')
-    .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'file_name'> | null;
+    .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
+    .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'> | null;
 
   if (!stash) {
     return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
@@ -211,6 +219,7 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
     data: {
       secretKey: decrypt(stash.secret_key),
       blobUrl: stash.blob_url,
+      blobSha256: stash.blob_sha256 ?? undefined,
       fileName: decrypt(stash.file_name),
     },
   });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -12,6 +12,7 @@ export type APIResponse<T> = { success: true; data: T } | { success: false; erro
 export interface Stash {
   id: string;
   blobUrl: string;
+  blobSha256?: string;
   secretKey: string;
   sellerPubkey: string;
   priceSats: number;
@@ -57,6 +58,7 @@ export interface Payment {
 // POST /api/stash
 export interface CreateStashRequest {
   blobUrl: string;
+  blobSha256?: string;
   secretKey: string;
   sellerPubkey: string;
   priceSats: number;
@@ -80,6 +82,7 @@ export interface UnlockRequest {
 export interface UnlockResponse {
   secretKey: string;
   blobUrl: string;
+  blobSha256?: string;
   fileName: string;
   claimToken?: string;
 }
@@ -143,6 +146,7 @@ export interface PayStatusResponse {
   paid: boolean;
   secretKey?: string;
   blobUrl?: string;
+  blobSha256?: string;
   fileName?: string;
   claimToken?: string;
 }


### PR DESCRIPTION
Fixes #9

Lets sellers pick which Blossom server to upload to. Settings page now has tabs (Payments/Account/Advanced) with server selection + custom URL in Advanced.

What's new:
- Blossom server presets (just Primal for now, most others don't support encrypted uploads yet)
- Custom server URL input with auto-https
- BUD-04 mirroring to backup servers with opt-out toggle
- SHA256-based download fallback if primary server goes down
- BUD-11 spec fixes: Base64url auth headers, X-SHA-256 on uploads, correct mirror auth tags
- Server stores blob_sha256 for fallback lookups (migration v6)

Known limitations:
- Most public Blossom servers reject encrypted blob uploads, so only Primal is preset for now
- First-time sellers can't configure server before creating identity
- Mirroring is effectively a no-op with only one preset server
