### PR TITLE
feat: add public seller storefront with per-stash visibility

### DIFF
--- a/client/src/components/DashboardPage.tsx
+++ b/client/src/components/DashboardPage.tsx
@@ -248,22 +248,24 @@ export function DashboardPage() {
             <h1 className="text-3xl font-bold text-white">Seller Dashboard</h1>
           </div>
           <div className="flex items-center gap-3 w-full sm:w-auto">
-            <button
-              onClick={async () => {
-                const { npub } = getOrCreateIdentity();
-                const url = `${window.location.origin}/p/${npub}`;
-                const success = await copyToClipboard(url);
-                if (success) {
-                  toast.showToast('Storefront link copied!', 'success');
-                } else {
-                  toast.showToast('Failed to copy link', 'error');
-                }
-              }}
-              className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
-              title="Copy Storefront Link"
-            >
-              <LinkIcon className="w-5 h-5 text-slate-400" />
-            </button>
+            {data?.storefrontEnabled && (
+              <button
+                onClick={async () => {
+                  const { npub } = getOrCreateIdentity();
+                  const url = `${window.location.origin}/p/${npub}`;
+                  const success = await copyToClipboard(url);
+                  if (success) {
+                    toast.showToast('Storefront link copied!', 'success');
+                  } else {
+                    toast.showToast('Failed to copy link', 'error');
+                  }
+                }}
+                className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
+                title="Copy Storefront Link"
+              >
+                <LinkIcon className="w-5 h-5 text-slate-400" />
+              </button>
+            )}
             <Link
               to="/settings"
               className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"

--- a/client/src/components/DashboardPage.tsx
+++ b/client/src/components/DashboardPage.tsx
@@ -9,9 +9,10 @@ import {
   Zap,
   History,
   Link as LinkIcon,
+  Store,
 } from 'lucide-react';
-import { getDashboard, getSettlements } from '../lib/api';
-import { getPublicKeyHex, hasIdentity } from '../lib/identity';
+import { getDashboard, getSettlements, toggleStashVisibility } from '../lib/api';
+import { getPublicKeyHex, getOrCreateIdentity, hasIdentity } from '../lib/identity';
 import { useToast } from './useToast';
 import { copyToClipboard } from '../lib/clipboard';
 import { WithdrawModal } from './WithdrawModal';
@@ -247,6 +248,22 @@ export function DashboardPage() {
             <h1 className="text-3xl font-bold text-white">Seller Dashboard</h1>
           </div>
           <div className="flex items-center gap-3 w-full sm:w-auto">
+            <button
+              onClick={async () => {
+                const { npub } = getOrCreateIdentity();
+                const url = `${window.location.origin}/p/${npub}`;
+                const success = await copyToClipboard(url);
+                if (success) {
+                  toast.showToast('Storefront link copied!', 'success');
+                } else {
+                  toast.showToast('Failed to copy link', 'error');
+                }
+              }}
+              className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
+              title="Copy Storefront Link"
+            >
+              <LinkIcon className="w-5 h-5 text-slate-400" />
+            </button>
             <Link
               to="/settings"
               className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
@@ -381,6 +398,39 @@ export function DashboardPage() {
                           <p className="text-slate-500 text-xs">Sats earned</p>
                         </div>
                       </div>
+
+                      <button
+                        onClick={async () => {
+                          const newValue = !stash.showInStorefront;
+                          try {
+                            await toggleStashVisibility(stash.id, newValue);
+                            stash.showInStorefront = newValue;
+                            setData({ ...data! });
+                            toast.showToast(
+                              newValue ? 'Visible in storefront' : 'Hidden from storefront',
+                              'success'
+                            );
+                          } catch {
+                            toast.showToast('Failed to update visibility', 'error');
+                          }
+                        }}
+                        className={`p-2 rounded-lg transition-colors ${
+                          stash.showInStorefront
+                            ? 'bg-violet-500/20 hover:bg-violet-500/30'
+                            : 'bg-slate-700 hover:bg-slate-600'
+                        }`}
+                        title={
+                          stash.showInStorefront
+                            ? 'Visible in storefront — click to hide'
+                            : 'Hidden from storefront — click to show'
+                        }
+                      >
+                        <Store
+                          className={`w-5 h-5 ${
+                            stash.showInStorefront ? 'text-violet-400' : 'text-slate-500'
+                          }`}
+                        />
+                      </button>
 
                       <button
                         onClick={async () => {

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -398,9 +398,9 @@ export function SettingsPage() {
                   />
                 </button>
               </div>
-              {storefrontEnabled && (
-                <div className="mt-4 pt-4 border-t border-slate-700/50">
-                  <p className="text-slate-500 text-sm">
+              <div className="mt-4 pt-4 border-t border-slate-700/50">
+                {storefrontEnabled && (
+                  <p className="text-slate-500 text-sm mb-3">
                     Your storefront:{' '}
                     <button
                       onClick={async () => {
@@ -415,14 +415,14 @@ export function SettingsPage() {
                       {window.location.origin}/p/{identity.npub.slice(0, 12)}…
                     </button>
                   </p>
-                  <div className="mt-3 p-3 bg-slate-700/30 border border-slate-700/50 rounded-lg">
-                    <p className="text-slate-400 text-xs">
-                      Your storefront URL contains your Nostr public key. Sharing it publicly will
-                      link your Nostr identity to your Stashu presence.
-                    </p>
-                  </div>
+                )}
+                <div className="p-3 bg-slate-700/30 border border-slate-700/50 rounded-lg">
+                  <p className="text-slate-400 text-xs">
+                    Your storefront URL contains your Nostr public key. Sharing it publicly will
+                    link your Nostr identity to your Stashu presence.
+                  </p>
                 </div>
-              )}
+              </div>
             </div>
 
             {/* Public Key */}

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   Save,
   Lightbulb,
   Server,
+  Store,
 } from 'lucide-react';
 import { hasIdentity, getOrCreateIdentity, getPublicKeyHex, clearIdentity } from '../lib/identity';
 import { getSettings, saveSettings } from '../lib/api';
@@ -43,6 +44,8 @@ export function SettingsPage() {
   const [threshold, setThreshold] = useState(0);
   const [savedLnAddress, setSavedLnAddress] = useState('');
   const [savedThreshold, setSavedThreshold] = useState(0);
+  const [storefrontEnabled, setStorefrontEnabled] = useState(false);
+  const [savingStorefront, setSavingStorefront] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadingSettings, setLoadingSettings] = useState(true);
   const [settingsChanged, setSettingsChanged] = useState(false);
@@ -68,6 +71,7 @@ export function SettingsPage() {
         .then((s) => {
           setLnAddress(s.lnAddress);
           setThreshold(s.autoWithdrawThreshold);
+          setStorefrontEnabled(s.storefrontEnabled);
           setSavedLnAddress(s.lnAddress);
           setSavedThreshold(s.autoWithdrawThreshold);
         })
@@ -126,6 +130,7 @@ export function SettingsPage() {
       await saveSettings(pubkey, {
         lnAddress,
         autoWithdrawThreshold: threshold,
+        storefrontEnabled,
       });
       toast.showToast('Settings saved!', 'success');
       setSavedLnAddress(lnAddress);
@@ -166,6 +171,26 @@ export function SettingsPage() {
     setBlossomServerState(normalized);
     setBlossomUrlError('');
     toast.showToast('Blossom server updated', 'success');
+  };
+
+  const handleToggleStorefront = async () => {
+    const newValue = !storefrontEnabled;
+    setSavingStorefront(true);
+    setStorefrontEnabled(newValue);
+    try {
+      const pubkey = getPublicKeyHex();
+      await saveSettings(pubkey, {
+        lnAddress: savedLnAddress,
+        autoWithdrawThreshold: savedThreshold,
+        storefrontEnabled: newValue,
+      });
+      toast.showToast(newValue ? 'Storefront enabled' : 'Storefront disabled', 'success');
+    } catch (err) {
+      setStorefrontEnabled(!newValue); // revert on failure
+      toast.showToast(err instanceof Error ? err.message : 'Failed to update', 'error');
+    } finally {
+      setSavingStorefront(false);
+    }
   };
 
   const thresholdPresets = [100, 500, 1000, 5000, 10000];
@@ -345,6 +370,61 @@ export function SettingsPage() {
         {/* Account Tab */}
         {activeTab === 'account' && (
           <>
+            {/* Public Storefront */}
+            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-xl bg-violet-500/20 flex items-center justify-center">
+                    <Store className="w-5 h-5 text-violet-400" />
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold text-white">Public Storefront</h2>
+                    <p className="text-slate-400 text-sm">
+                      Let anyone browse all your stashes from one link.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={handleToggleStorefront}
+                  disabled={savingStorefront || loadingSettings}
+                  className={`relative w-12 h-7 rounded-full transition-colors ${
+                    savingStorefront ? 'opacity-50 cursor-not-allowed' : ''
+                  } ${storefrontEnabled ? 'bg-violet-500' : 'bg-slate-600'}`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full transition-transform ${
+                      storefrontEnabled ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </div>
+              {storefrontEnabled && (
+                <div className="mt-4 pt-4 border-t border-slate-700/50">
+                  <p className="text-slate-500 text-sm">
+                    Your storefront:{' '}
+                    <button
+                      onClick={async () => {
+                        const url = `${window.location.origin}/p/${identity.npub}`;
+                        const success = await copyToClipboard(url);
+                        if (success) {
+                          toast.showToast('Storefront link copied!', 'success');
+                        }
+                      }}
+                      className="text-violet-400 hover:text-violet-300 underline transition-colors"
+                    >
+                      {window.location.origin}/p/{identity.npub.slice(0, 12)}…
+                    </button>
+                  </p>
+                  <div className="mt-3 p-3 bg-slate-700/30 border border-slate-700/50 rounded-lg">
+                    <p className="text-slate-400 text-xs">
+                      Your storefront URL contains your Nostr public key. Sharing it publicly will
+                      link your Nostr identity to your Stashu presence.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+
             {/* Public Key */}
             <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
               <div className="flex items-center gap-2 mb-4">

--- a/client/src/components/StorefrontPage.tsx
+++ b/client/src/components/StorefrontPage.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { XCircle, Package, Squirrel, FileText } from 'lucide-react';
+import { decode } from 'nostr-tools/nip19';
+import { getSellerStorefront } from '../lib/api';
+import type { StashPublicInfo } from '../../../shared/types';
+
+type LoadingState = 'loading' | 'ready' | 'error' | 'not-enabled' | 'not-found';
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Decode npub to hex pubkey. Returns null if invalid. */
+function npubToHex(npub: string): string | null {
+  try {
+    const decoded = decode(npub);
+    if (decoded.type !== 'npub') return null;
+    return decoded.data as string;
+  } catch {
+    return null;
+  }
+}
+
+export function StorefrontPage() {
+  const { npub } = useParams<{ npub: string }>();
+  const [state, setState] = useState<LoadingState>('loading');
+  const [stashes, setStashes] = useState<StashPublicInfo[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const hexPubkey = npub ? npubToHex(npub) : null;
+
+  useEffect(() => {
+    if (!hexPubkey) {
+      // Defer state update to avoid synchronous setState in effect body
+      const id = requestAnimationFrame(() => setState('not-found'));
+      return () => cancelAnimationFrame(id);
+    }
+
+    let cancelled = false;
+
+    getSellerStorefront(hexPubkey)
+      .then((data) => {
+        if (!cancelled) {
+          setStashes(data);
+          setState('ready');
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : 'Failed to load storefront';
+          if (msg === 'Storefront is not enabled') {
+            setState('not-enabled');
+          } else if (msg === 'Seller not found') {
+            setState('not-found');
+          } else {
+            setError(msg);
+            setState('error');
+          }
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hexPubkey]);
+
+  // Loading skeleton
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen bg-slate-900 py-12 px-6">
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-8">
+            <div className="skeleton h-4 w-24 mb-3" />
+            <div className="skeleton h-8 w-56 mb-2" />
+            <div className="skeleton h-4 w-40" />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="bg-slate-800/30 border border-slate-700/50 rounded-xl p-6"
+                style={{ opacity: 1 - i * 0.2 }}
+              >
+                <div className="skeleton h-32 w-full rounded-lg mb-4" />
+                <div className="skeleton h-5 w-3/4 mb-2" />
+                <div className="skeleton h-4 w-1/2" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Seller not found (invalid npub or never used Stashu)
+  if (state === 'not-found') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center p-6">
+        <div className="max-w-md w-full text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-slate-700 flex items-center justify-center">
+            <Squirrel className="w-8 h-8 text-slate-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-white mb-4">Seller Not Found</h1>
+          <p className="text-slate-400 mb-8">
+            This seller doesn't exist on Stashu or the link is invalid.
+          </p>
+          <Link
+            to="/"
+            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Storefront not enabled
+  if (state === 'not-enabled') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center p-6">
+        <div className="max-w-md w-full text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-slate-700 flex items-center justify-center">
+            <Squirrel className="w-8 h-8 text-slate-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-white mb-4">Storefront Not Available</h1>
+          <p className="text-slate-400 mb-8">This seller hasn't enabled their public storefront.</p>
+          <Link
+            to="/"
+            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (state === 'error') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center p-6">
+        <div className="max-w-md w-full text-center">
+          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-rose-500/20 flex items-center justify-center">
+            <XCircle className="w-8 h-8 text-rose-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-white mb-4">Failed to Load Storefront</h1>
+          <p className="text-slate-400 mb-8">{error}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Short npub for display
+  const shortNpub = npub ? `${npub.slice(0, 12)}…${npub.slice(-6)}` : '';
+
+  return (
+    <div className="min-h-screen bg-slate-900 py-12 px-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <Link
+            to="/"
+            className="text-slate-400 hover:text-white text-sm mb-2 inline-block transition-colors"
+          >
+            ← Back to Home
+          </Link>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 rounded-xl bg-orange-500/20 flex items-center justify-center">
+              <Squirrel className="w-5 h-5 text-orange-400" />
+            </div>
+            <h1 className="text-3xl font-bold text-white">Storefront</h1>
+          </div>
+          <p className="text-slate-500 text-sm font-mono">{shortNpub}</p>
+        </div>
+
+        {/* Empty state */}
+        {stashes.length === 0 ? (
+          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-8 text-center">
+            <div className="w-12 h-12 mx-auto mb-4 rounded-xl bg-slate-700 flex items-center justify-center">
+              <Package className="w-6 h-6 text-slate-400" />
+            </div>
+            <p className="text-slate-400">This seller has no stashes yet.</p>
+          </div>
+        ) : (
+          <>
+            <p className="text-slate-400 text-sm mb-4">
+              {stashes.length} stash{stashes.length !== 1 ? 'es' : ''} available
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {stashes.map((stash) => (
+                <Link
+                  key={stash.id}
+                  to={`/s/${stash.id}`}
+                  className="group bg-slate-800/50 border border-slate-700 rounded-xl overflow-hidden hover:border-orange-500/50 transition-colors"
+                >
+                  {/* Preview image or placeholder */}
+                  {stash.previewUrl ? (
+                    <div className="aspect-video bg-slate-800 overflow-hidden">
+                      <img
+                        src={stash.previewUrl}
+                        alt={stash.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                    </div>
+                  ) : (
+                    <div className="aspect-video bg-slate-800/80 flex items-center justify-center">
+                      <FileText className="w-10 h-10 text-slate-600" />
+                    </div>
+                  )}
+
+                  {/* Info */}
+                  <div className="p-4">
+                    <h3 className="text-white font-semibold mb-1 truncate group-hover:text-orange-400 transition-colors">
+                      {stash.title}
+                    </h3>
+                    {stash.description && (
+                      <p className="text-slate-400 text-sm mb-2 line-clamp-2">
+                        {stash.description}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between">
+                      <span className="text-orange-400 font-bold">
+                        {stash.priceSats.toLocaleString()} sats
+                      </span>
+                      <span className="text-slate-500 text-xs">
+                        {formatFileSize(stash.fileSize)}
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -7,3 +7,4 @@ export { ToastProvider } from './Toast';
 export { useToast } from './useToast';
 export { RecoveryTokenModal } from './RecoveryTokenModal';
 export { SettingsPage } from './SettingsPage';
+export { StorefrontPage } from './StorefrontPage';

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -252,6 +252,46 @@ export async function saveSettings(
 /**
  * Get settlement history for a seller
  */
+/**
+ * Toggle a stash's storefront visibility
+ */
+export async function toggleStashVisibility(
+  stashId: string,
+  showInStorefront: boolean
+): Promise<{ showInStorefront: boolean }> {
+  const url = `${API_BASE}/stash/${stashId}/visibility`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: createAuthHeader(url, 'POST'),
+    },
+    body: JSON.stringify({ showInStorefront }),
+  });
+
+  const result: APIResponse<{ showInStorefront: boolean }> = await response.json();
+
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}
+
+/**
+ * Get all stashes by a seller (public storefront, no auth)
+ */
+export async function getSellerStorefront(pubkey: string): Promise<StashPublicInfo[]> {
+  const response = await fetch(`${API_BASE}/seller/${pubkey}`);
+  const result: APIResponse<StashPublicInfo[]> = await response.json();
+
+  if (!result.success) {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}
+
 export async function getSettlements(pubkey: string): Promise<SettlementLogEntry[]> {
   const url = `${API_BASE}/dashboard/${pubkey}/settlements`;
   const response = await fetch(url, {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,6 +8,7 @@ import {
   DashboardPage,
   RestorePage,
   SettingsPage,
+  StorefrontPage,
   ToastProvider,
 } from './components';
 import NotFoundPage from './components/NotFoundPage.tsx';
@@ -24,6 +25,7 @@ createRoot(document.getElementById('root')!).render(
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/restore" element={<RestorePage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/p/:npub" element={<StorefrontPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </BrowserRouter>

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Vitest setup: ensure localStorage works correctly in the test environment.
+ *
+ * Some versions of happy-dom + Node's --localstorage-file flag produce a
+ * Proxy-backed localStorage missing removeItem. Replace it with a simple
+ * Map-based implementation for tests.
+ */
+const store = new Map<string, string>();
+
+const testStorage: Storage = {
+  get length() {
+    return store.size;
+  },
+  key(index: number) {
+    return [...store.keys()][index] ?? null;
+  },
+  getItem(key: string) {
+    return store.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    store.set(key, String(value));
+  },
+  removeItem(key: string) {
+    store.delete(key);
+  },
+  clear() {
+    store.clear();
+  },
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: testStorage,
+  writable: true,
+  configurable: true,
+});

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -358,6 +358,22 @@ const currentVersion = (
         console.log('🔗 Added blob_sha256 column to stashes for BUD-04 mirroring fallback.');
       },
     },
+    {
+      version: 7,
+      name: 'add storefront_enabled to seller_settings',
+      run: () => {
+        db.exec(`ALTER TABLE seller_settings ADD COLUMN storefront_enabled INTEGER DEFAULT 0`);
+        console.log('🏪 Added storefront_enabled column to seller_settings.');
+      },
+    },
+    {
+      version: 8,
+      name: 'add show_in_storefront to stashes',
+      run: () => {
+        db.exec(`ALTER TABLE stashes ADD COLUMN show_in_storefront INTEGER DEFAULT 0`);
+        console.log('🏪 Added show_in_storefront column to stashes.');
+      },
+    },
   ];
 
   // Run pending migrations in a transaction

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -20,6 +20,7 @@ export interface StashRow {
   file_name: string; // encrypted
   file_size: number;
   preview_url: string | null;
+  show_in_storefront: number;
   created_at: number;
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,7 @@ import { dashboardRoutes } from './routes/dashboard.js';
 import { withdrawRoutes } from './routes/withdraw.js';
 import { payRoutes } from './routes/pay.js';
 import { settingsRoutes } from './routes/settings.js';
+import { sellerRoutes } from './routes/seller.js';
 import { requireAuth } from './middleware/auth.js';
 import { rateLimit } from './middleware/ratelimit.js';
 
@@ -53,7 +54,12 @@ app.route('/api/pay', payRoutes);
 // Stash routes — GET is public (buyer preview), POST requires auth (prevents spoofing)
 app.use('/api/stash/*', rateLimit(60_000, 10)); // 10 req/min
 app.post('/api/stash', requireAuth); // Auth only on creation, not preview
+app.post('/api/stash/:id/visibility', requireAuth); // Auth on visibility toggle
 app.route('/api/stash', stashRoutes);
+
+// Seller storefront — public, no auth
+app.use('/api/seller/*', rateLimit(60_000, 30)); // 30 req/min
+app.route('/api/seller', sellerRoutes);
 
 // Protected API routes (require Nostr signature)
 app.use('/api/earnings/*', requireAuth);

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -66,11 +66,16 @@ dashboardRoutes.get('/:pubkey', async (c) => {
     const tokens = tokenRows.map((r) => decrypt(r.seller_token));
     const totalSats = tokenRows.reduce((sum, r) => sum + r.price_sats, 0);
 
+    const settingsRow = db
+      .prepare('SELECT storefront_enabled FROM seller_settings WHERE pubkey = ?')
+      .get(pubkey) as { storefront_enabled: number } | undefined;
+
     return c.json<APIResponse<DashboardResponse>>({
       success: true,
       data: {
         stashes,
         earnings: { tokens, totalSats },
+        storefrontEnabled: settingsRow?.storefront_enabled === 1,
       },
     });
   } catch (error) {

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -16,11 +16,12 @@ dashboardRoutes.get('/:pubkey', async (c) => {
     const pubkey = c.get('authedPubkey');
 
     const stashesStmt = db.prepare(`
-      SELECT 
+      SELECT
         s.id,
         s.title,
         s.price_sats,
         s.created_at,
+        s.show_in_storefront,
         COUNT(CASE WHEN p.status = 'paid' THEN 1 END) as unlock_count,
         COALESCE(SUM(CASE WHEN p.status = 'paid' THEN s.price_sats ELSE 0 END), 0) as total_earned
       FROM stashes s
@@ -35,6 +36,7 @@ dashboardRoutes.get('/:pubkey', async (c) => {
       title: string;
       price_sats: number;
       created_at: number;
+      show_in_storefront: number;
       unlock_count: number;
       total_earned: number;
     }>;
@@ -46,6 +48,7 @@ dashboardRoutes.get('/:pubkey', async (c) => {
       unlockCount: row.unlock_count,
       totalEarned: row.total_earned,
       createdAt: row.created_at,
+      showInStorefront: row.show_in_storefront === 1,
     }));
 
     const tokensStmt = db.prepare(`

--- a/server/src/routes/seller.test.ts
+++ b/server/src/routes/seller.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for seller storefront public endpoint.
+ *
+ * Run with: npm test --workspace=server
+ */
+
+// Set env before any db-dependent imports
+if (!process.env.TOKEN_ENCRYPTION_KEY) {
+  const { randomBytes } = await import('node:crypto');
+  process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+}
+process.env.DB_PATH = ':memory:';
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+
+const db = (await import('../db/index.js')).default;
+const { sellerRoutes } = await import('./seller.js');
+const { stashRoutes } = await import('./stash.js');
+const { requireAuth } = await import('../middleware/auth.js');
+const { encrypt } = await import('../lib/encryption.js');
+const { createKeypair, makeNip98Header } = await import('../test/helpers.js');
+
+type AuthVars = { authedPubkey: string };
+const app = new Hono<{ Variables: AuthVars }>();
+app.post('/api/stash', requireAuth);
+app.post('/api/stash/:id/visibility', requireAuth);
+app.route('/api/stash', stashRoutes);
+app.route('/api/seller', sellerRoutes);
+
+const { sk, pk } = createKeypair();
+const { pk: otherPk } = createKeypair();
+
+function auth(method: string, path: string) {
+  return makeNip98Header(method, `http://localhost${path}`, sk);
+}
+
+function insertStash(opts: { showInStorefront?: number; sellerPubkey?: string } = {}) {
+  const id = crypto.randomUUID();
+  db.prepare(
+    `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size, show_in_storefront, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())`
+  ).run(
+    id,
+    'https://blossom.example.com/abc',
+    encrypt('secret-key'),
+    opts.sellerPubkey ?? pk,
+    100,
+    encrypt('Test Stash'),
+    encrypt('file.pdf'),
+    1024,
+    opts.showInStorefront ?? 0
+  );
+  return id;
+}
+
+function enableStorefront(pubkey: string) {
+  db.prepare(
+    `INSERT INTO seller_settings (pubkey, storefront_enabled, updated_at)
+     VALUES (?, 1, unixepoch())
+     ON CONFLICT(pubkey) DO UPDATE SET storefront_enabled = 1, updated_at = unixepoch()`
+  ).run(pubkey);
+}
+
+beforeEach(() => {
+  db.exec('DELETE FROM payments');
+  db.exec('DELETE FROM stashes');
+  db.exec('DELETE FROM seller_settings');
+});
+
+describe('GET /api/seller/:pubkey', () => {
+  it('returns 400 for invalid pubkey format', async () => {
+    const res = await app.request('/api/seller/not-a-hex-pubkey');
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.success, false);
+    assert.match(body.error, /pubkey/i);
+  });
+
+  it('returns 404 for unknown seller', async () => {
+    const fakePk = 'a'.repeat(64);
+    const res = await app.request(`/api/seller/${fakePk}`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'Seller not found');
+  });
+
+  it('returns 404 when storefront is not enabled', async () => {
+    insertStash({ showInStorefront: 1 });
+    // No seller_settings row → storefront not enabled
+    const res = await app.request(`/api/seller/${pk}`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'Storefront is not enabled');
+  });
+
+  it('returns 404 when storefront is explicitly disabled', async () => {
+    insertStash({ showInStorefront: 1 });
+    db.prepare(
+      `INSERT INTO seller_settings (pubkey, storefront_enabled, updated_at) VALUES (?, 0, unixepoch())`
+    ).run(pk);
+    const res = await app.request(`/api/seller/${pk}`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'Storefront is not enabled');
+  });
+
+  it('returns empty array when storefront enabled but no visible stashes', async () => {
+    insertStash({ showInStorefront: 0 }); // hidden
+    enableStorefront(pk);
+    const res = await app.request(`/api/seller/${pk}`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 0);
+  });
+
+  it('returns only visible stashes with decrypted metadata', async () => {
+    const visibleId = insertStash({ showInStorefront: 1 });
+    insertStash({ showInStorefront: 0 }); // hidden
+    enableStorefront(pk);
+
+    const res = await app.request(`/api/seller/${pk}`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.success, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].id, visibleId);
+    assert.equal(body.data[0].title, 'Test Stash');
+    assert.equal(body.data[0].fileName, 'file.pdf');
+    assert.equal(body.data[0].priceSats, 100);
+  });
+
+  it('does not return stashes from other sellers', async () => {
+    insertStash({ showInStorefront: 1, sellerPubkey: otherPk });
+    insertStash({ showInStorefront: 1 });
+    enableStorefront(pk);
+
+    const res = await app.request(`/api/seller/${pk}`);
+    const body = await res.json();
+    assert.equal(body.data.length, 1);
+  });
+});
+
+describe('POST /api/stash/:id/visibility', () => {
+  it('returns 404 for non-existent stash', async () => {
+    const path = '/api/stash/nonexistent/visibility';
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: true }),
+    });
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 400 for malformed JSON body', async () => {
+    const id = insertStash();
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: 'not json',
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /json/i);
+  });
+
+  it('returns 400 for non-boolean showInStorefront', async () => {
+    const id = insertStash();
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: 'yes' }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /boolean/i);
+  });
+
+  it('returns 403 when toggling another sellers stash', async () => {
+    const id = insertStash({ sellerPubkey: otherPk });
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: true }),
+    });
+    assert.equal(res.status, 403);
+  });
+
+  it('toggles visibility on', async () => {
+    const id = insertStash({ showInStorefront: 0 });
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: true }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.success, true);
+    assert.equal(body.data.showInStorefront, true);
+
+    // Verify in DB
+    const row = db.prepare('SELECT show_in_storefront FROM stashes WHERE id = ?').get(id) as {
+      show_in_storefront: number;
+    };
+    assert.equal(row.show_in_storefront, 1);
+  });
+
+  it('toggles visibility off', async () => {
+    const id = insertStash({ showInStorefront: 1 });
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: false }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.showInStorefront, false);
+
+    const row = db.prepare('SELECT show_in_storefront FROM stashes WHERE id = ?').get(id) as {
+      show_in_storefront: number;
+    };
+    assert.equal(row.show_in_storefront, 0);
+  });
+});

--- a/server/src/routes/seller.ts
+++ b/server/src/routes/seller.ts
@@ -1,0 +1,91 @@
+import { Hono } from 'hono';
+import db from '../db/index.js';
+import { decrypt } from '../lib/encryption.js';
+import type { StashPublicInfo, APIResponse } from '../../../shared/types.js';
+import type { StashRow } from '../db/types.js';
+
+export const sellerRoutes = new Hono();
+
+// GET /api/seller/:pubkey - Get all stashes by a seller (public, no auth)
+sellerRoutes.get('/:pubkey', async (c) => {
+  try {
+    const pubkey = c.req.param('pubkey');
+
+    // Validate pubkey format (64 hex chars)
+    if (!/^[0-9a-f]{64}$/.test(pubkey)) {
+      return c.json<APIResponse<never>>({ success: false, error: 'Invalid pubkey format' }, 400);
+    }
+
+    // Check if seller has enabled their storefront (also proves they exist)
+    const settings = db
+      .prepare('SELECT storefront_enabled FROM seller_settings WHERE pubkey = ?')
+      .get(pubkey) as { storefront_enabled: number } | undefined;
+
+    if (!settings) {
+      // No settings row → check if they have stashes (used Stashu but never saved settings)
+      const hasStashes = db
+        .prepare('SELECT 1 FROM stashes WHERE seller_pubkey = ? LIMIT 1')
+        .get(pubkey);
+
+      if (!hasStashes) {
+        return c.json<APIResponse<never>>({ success: false, error: 'Seller not found' }, 404);
+      }
+
+      // Seller exists but never enabled storefront
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'Storefront is not enabled' },
+        404
+      );
+    }
+
+    if (settings.storefront_enabled !== 1) {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'Storefront is not enabled' },
+        404
+      );
+    }
+
+    const stmt = db.prepare(`
+      SELECT id, title, description, file_name, file_size, price_sats, preview_url, created_at
+      FROM stashes
+      WHERE seller_pubkey = ? AND show_in_storefront = 1
+      ORDER BY created_at DESC
+    `);
+
+    const rows = stmt.all(pubkey) as Pick<
+      StashRow,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'file_name'
+      | 'file_size'
+      | 'price_sats'
+      | 'preview_url'
+      | 'created_at'
+    >[];
+
+    const stashes: StashPublicInfo[] = rows.map((row) => ({
+      id: row.id,
+      title: decrypt(row.title),
+      description: row.description ? decrypt(row.description) : undefined,
+      fileName: decrypt(row.file_name),
+      fileSize: row.file_size,
+      priceSats: row.price_sats,
+      previewUrl: row.preview_url ?? undefined,
+    }));
+
+    return c.json<APIResponse<StashPublicInfo[]>>({
+      success: true,
+      data: stashes,
+    });
+  } catch (error) {
+    console.error('Error fetching seller storefront:', error);
+    return c.json<APIResponse<never>>(
+      {
+        success: false,
+        error: 'Failed to fetch storefront',
+      },
+      500
+    );
+  }
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -13,12 +13,17 @@ settingsRoutes.get('/:pubkey', async (c) => {
     const pubkey = c.get('authedPubkey');
 
     const row = db
-      .prepare('SELECT ln_address, auto_withdraw_threshold FROM seller_settings WHERE pubkey = ?')
-      .get(pubkey) as { ln_address: string | null; auto_withdraw_threshold: number } | undefined;
+      .prepare(
+        'SELECT ln_address, auto_withdraw_threshold, storefront_enabled FROM seller_settings WHERE pubkey = ?'
+      )
+      .get(pubkey) as
+      | { ln_address: string | null; auto_withdraw_threshold: number; storefront_enabled: number }
+      | undefined;
 
     const settings: SellerSettings = {
       lnAddress: row?.ln_address ? decrypt(row.ln_address) : '',
       autoWithdrawThreshold: row?.auto_withdraw_threshold || 0,
+      storefrontEnabled: row?.storefront_enabled === 1,
     };
 
     return c.json<APIResponse<SellerSettings>>({
@@ -48,14 +53,17 @@ settingsRoutes.post('/:pubkey', async (c) => {
     // Validate threshold
     const threshold = Math.max(0, Math.floor(body.autoWithdrawThreshold || 0));
 
+    const storefrontEnabled = body.storefrontEnabled ? 1 : 0;
+
     db.prepare(
-      `INSERT INTO seller_settings (pubkey, ln_address, auto_withdraw_threshold, updated_at)
-       VALUES (?, ?, ?, unixepoch())
+      `INSERT INTO seller_settings (pubkey, ln_address, auto_withdraw_threshold, storefront_enabled, updated_at)
+       VALUES (?, ?, ?, ?, unixepoch())
        ON CONFLICT(pubkey) DO UPDATE SET
          ln_address = excluded.ln_address,
          auto_withdraw_threshold = excluded.auto_withdraw_threshold,
+         storefront_enabled = excluded.storefront_enabled,
          updated_at = unixepoch()`
-    ).run(pubkey, body.lnAddress ? encrypt(body.lnAddress) : null, threshold);
+    ).run(pubkey, body.lnAddress ? encrypt(body.lnAddress) : null, threshold, storefrontEnabled);
 
     // Trigger auto-settlement for any existing unclaimed balance
     tryAutoSettle(pubkey).catch(() => {});
@@ -65,6 +73,7 @@ settingsRoutes.post('/:pubkey', async (c) => {
       data: {
         lnAddress: body.lnAddress || '',
         autoWithdrawThreshold: threshold,
+        storefrontEnabled: body.storefrontEnabled ?? false,
       },
     });
   } catch (error) {

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -111,6 +111,55 @@ stashRoutes.post('/', async (c) => {
   }
 });
 
+// POST /api/stash/:id/visibility - Toggle storefront visibility (requires NIP-98 auth)
+stashRoutes.post('/:id/visibility', async (c) => {
+  try {
+    const pubkey = c.get('authedPubkey');
+    const id = c.req.param('id');
+
+    let body: { showInStorefront: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json<APIResponse<never>>({ success: false, error: 'Invalid JSON body' }, 400);
+    }
+
+    if (typeof body.showInStorefront !== 'boolean') {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'showInStorefront must be a boolean' },
+        400
+      );
+    }
+
+    // Verify the stash belongs to this seller
+    const stash = db
+      .prepare('SELECT seller_pubkey, show_in_storefront FROM stashes WHERE id = ?')
+      .get(id) as { seller_pubkey: string; show_in_storefront: number } | null;
+
+    if (!stash) {
+      return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
+    }
+
+    if (stash.seller_pubkey !== pubkey) {
+      return c.json<APIResponse<never>>({ success: false, error: 'Not your stash' }, 403);
+    }
+
+    const newValue = body.showInStorefront ? 1 : 0;
+    db.prepare('UPDATE stashes SET show_in_storefront = ? WHERE id = ?').run(newValue, id);
+
+    return c.json<APIResponse<{ showInStorefront: boolean }>>({
+      success: true,
+      data: { showInStorefront: body.showInStorefront },
+    });
+  } catch (error) {
+    console.error('Error toggling visibility:', error);
+    return c.json<APIResponse<never>>(
+      { success: false, error: 'Failed to update visibility' },
+      500
+    );
+  }
+});
+
 // GET /api/stash/:id - Get public stash info
 stashRoutes.get('/:id', async (c) => {
   try {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -107,6 +107,7 @@ export interface SellerStashStats {
 export interface DashboardResponse {
   stashes: SellerStashStats[];
   earnings: EarningsResponse;
+  storefrontEnabled: boolean;
 }
 
 // POST /api/withdraw/quote

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -100,6 +100,7 @@ export interface SellerStashStats {
   unlockCount: number;
   totalEarned: number;
   createdAt: number;
+  showInStorefront: boolean;
 }
 
 // GET /api/dashboard/:pubkey
@@ -165,6 +166,7 @@ export interface LnAddressResolveResponse {
 export interface SellerSettings {
   lnAddress: string;
   autoWithdrawThreshold: number; // in sats, 0 = disabled
+  storefrontEnabled: boolean;
 }
 
 // GET /api/dashboard/:pubkey/settlements


### PR DESCRIPTION
Fixes #33 
Added a public storefront page so sellers can share one link (/p/npub...) instead of sharing each stash separately. There's a toggle in settings to enable/disable it, and you can pick which stashes show up from the dashboard. Everything defaults to off so nothing goes public until the seller opts in.

Also fixed the client test suite- localStorage wasn't working properly in happy-dom, so all identity tests were failing. Added backend tests for the new endpoints too.
