### PR TITLE
feat: add verified previews for stashes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -58,10 +58,7 @@ function App() {
             <p className="text-(--color-text-secondary) text-sm mb-6">
               Upload, set price, get shareable link.
             </p>
-            <Link
-              to="/sell"
-              className="btn-primary w-full shadow-lg shadow-orange-500/20 block text-center py-3 text-sm font-semibold tracking-wide hover:shadow-orange-500/30 hover:-translate-y-0.5 transition-all duration-200"
-            >
+            <Link to="/sell" className="btn-primary w-full py-3 text-sm">
               {userHasIdentity ? 'Create Stash' : 'Get Started'}
             </Link>
           </div>

--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import { Route, Routes, useLocation } from 'react-router-dom';
+import App from './App';
+import {
+  DashboardPage,
+  RestorePage,
+  SellPage,
+  SettingsPage,
+  StorefrontPage,
+  UnlockPage,
+} from './components';
+import NotFoundPage from './components/NotFoundPage';
+
+function RouteTransition({ children }: { children: ReactNode }) {
+  const location = useLocation();
+
+  return (
+    <div key={location.pathname} className="route-appear">
+      {children}
+    </div>
+  );
+}
+
+export function AppRoutes() {
+  return (
+    <RouteTransition>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/sell" element={<SellPage />} />
+        <Route path="/s/:id" element={<UnlockPage />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/restore" element={<RestorePage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/p/:npub" element={<StorefrontPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </RouteTransition>
+  );
+}

--- a/client/src/components/DashboardPage.tsx
+++ b/client/src/components/DashboardPage.tsx
@@ -416,20 +416,29 @@ export function DashboardPage() {
                             toast.showToast('Failed to update visibility', 'error');
                           }
                         }}
+                        disabled={!data!.storefrontEnabled}
                         className={`p-2 rounded-lg transition-colors ${
-                          stash.showInStorefront
-                            ? 'bg-violet-500/20 hover:bg-violet-500/30'
-                            : 'bg-slate-700 hover:bg-slate-600'
+                          !data!.storefrontEnabled
+                            ? 'bg-slate-800 cursor-not-allowed opacity-50'
+                            : stash.showInStorefront
+                              ? 'bg-violet-500/20 hover:bg-violet-500/30'
+                              : 'bg-slate-700 hover:bg-slate-600'
                         }`}
                         title={
-                          stash.showInStorefront
-                            ? 'Visible in storefront — click to hide'
-                            : 'Hidden from storefront — click to show'
+                          !data!.storefrontEnabled
+                            ? 'Enable your public storefront in Settings first'
+                            : stash.showInStorefront
+                              ? 'Visible in storefront — click to hide'
+                              : 'Hidden from storefront — click to show'
                         }
                       >
                         <Store
                           className={`w-5 h-5 ${
-                            stash.showInStorefront ? 'text-violet-400' : 'text-slate-500'
+                            !data!.storefrontEnabled
+                              ? 'text-slate-600'
+                              : stash.showInStorefront
+                                ? 'text-violet-400'
+                                : 'text-slate-500'
                           }`}
                         />
                       </button>

--- a/client/src/components/DashboardPage.tsx
+++ b/client/src/components/DashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   History,
   Link as LinkIcon,
   Store,
+  Plus,
 } from 'lucide-react';
 import { getDashboard, getSettlements, toggleStashVisibility } from '../lib/api';
 import { getPublicKeyHex, getOrCreateIdentity, hasIdentity } from '../lib/identity';
@@ -127,10 +128,7 @@ export function DashboardPage() {
           <p className="text-slate-400 mb-8">
             Create a stash first to generate your seller identity.
           </p>
-          <Link
-            to="/sell"
-            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <Link to="/sell" className="btn-primary px-6 py-3">
             Create a Stash
           </Link>
         </div>
@@ -214,10 +212,7 @@ export function DashboardPage() {
           </div>
           <h1 className="text-2xl font-bold text-white mb-4">Error Loading Dashboard</h1>
           <p className="text-slate-400 mb-8">{error}</p>
-          <button
-            onClick={() => window.location.reload()}
-            className="py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <button onClick={() => window.location.reload()} className="btn-primary px-6 py-3">
             Try Again
           </button>
         </div>
@@ -260,30 +255,28 @@ export function DashboardPage() {
                     toast.showToast('Failed to copy link', 'error');
                   }
                 }}
-                className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
+                className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-700/70 bg-slate-800/60 text-slate-400 transition-all hover:border-slate-500/70 hover:bg-slate-700/70 hover:text-white"
                 title="Copy Storefront Link"
               >
-                <LinkIcon className="w-5 h-5 text-slate-400" />
+                <LinkIcon className="w-5 h-5" />
               </button>
             )}
             <Link
               to="/settings"
-              className="p-2 bg-slate-800 hover:bg-slate-700 rounded-xl transition-colors"
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-700/70 bg-slate-800/60 text-slate-400 transition-all hover:border-slate-500/70 hover:bg-slate-700/70 hover:text-white"
               title="Settings"
             >
-              <Settings className="w-5 h-5 text-slate-400" />
+              <Settings className="w-5 h-5" />
             </Link>
-            <Link
-              to="/sell"
-              className="flex-1 sm:flex-initial text-center py-2 px-4 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-            >
-              + New Stash
+            <Link to="/sell" className="btn-primary h-10 flex-1 px-4 py-0 text-sm sm:flex-initial">
+              <Plus className="h-4 w-4" />
+              New Stash
             </Link>
           </div>
         </div>
 
         {/* Earnings Card */}
-        <div className="relative bg-linear-to-br from-orange-500/20 to-amber-500/10 border border-orange-500/30 rounded-2xl p-8 mb-8">
+        <div className="relative mb-8 rounded-2xl border border-orange-500/25 bg-linear-to-br from-orange-500/16 to-amber-500/8 p-6 sm:p-8">
           <div className="flex flex-col gap-8">
             <div className="flex flex-col sm:flex-row items-center justify-between gap-8 sm:gap-0">
               <div className="flex flex-col sm:flex-row items-center gap-8 sm:gap-12 w-full sm:w-auto">
@@ -330,7 +323,11 @@ export function DashboardPage() {
                   <button
                     onClick={() => setShowWithdraw(true)}
                     disabled={availableBalance === 0}
-                    className="w-full sm:w-auto py-3 px-6 bg-amber-500 hover:bg-amber-600 disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-colors flex items-center justify-center gap-2"
+                    className={`flex w-full items-center justify-center gap-2 rounded-xl border px-6 py-3 font-semibold transition-all sm:w-auto ${
+                      availableBalance === 0
+                        ? 'cursor-not-allowed border-slate-700/70 bg-slate-900/35 text-slate-500'
+                        : 'border-amber-300/20 bg-amber-500/85 text-white hover:bg-amber-500'
+                    }`}
                   >
                     <Zap
                       className={`w-4 h-4 ${availableBalance === 0 ? 'text-slate-500' : 'text-white'}`}
@@ -340,7 +337,7 @@ export function DashboardPage() {
                   {data!.earnings.tokens.length > 0 && (
                     <button
                       onClick={copyAllTokens}
-                      className="w-full sm:w-auto py-3 px-6 bg-slate-800 hover:bg-slate-700 text-slate-300 font-semibold rounded-xl transition-colors flex items-center justify-center gap-2"
+                      className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-700/70 bg-slate-800/55 px-6 py-3 font-semibold text-slate-300 transition-all hover:border-slate-500/70 hover:bg-slate-700/70 hover:text-white sm:w-auto"
                     >
                       <Copy className="w-4 h-4" />
                       Copy Tokens
@@ -362,10 +359,8 @@ export function DashboardPage() {
                 <Package className="w-6 h-6 text-slate-400" />
               </div>
               <p className="text-slate-400 mb-4">No stashes yet. Create your first one!</p>
-              <Link
-                to="/sell"
-                className="inline-block py-2 px-4 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-              >
+              <Link to="/sell" className="btn-primary px-4 py-2 text-sm">
+                <Plus className="h-4 w-4" />
                 Create Stash
               </Link>
             </div>

--- a/client/src/components/NotFoundPage.tsx
+++ b/client/src/components/NotFoundPage.tsx
@@ -9,10 +9,7 @@ function NotFoundPage() {
         <p className="text-(--color-text-secondary) mb-8 leading-relaxed">
           This page doesn't exist. Maybe the stash was removed, or you followed a broken link.
         </p>
-        <Link
-          to="/"
-          className="btn-primary inline-block px-8 py-3 text-sm font-semibold tracking-wide"
-        >
+        <Link to="/" className="btn-primary px-8 py-3 text-sm">
           Go Home
         </Link>
       </div>

--- a/client/src/components/RecoveryTokenModal.tsx
+++ b/client/src/components/RecoveryTokenModal.tsx
@@ -115,11 +115,7 @@ export function RecoveryTokenModal({ onComplete }: RecoveryTokenModalProps) {
         <button
           onClick={handleContinue}
           disabled={!acknowledged}
-          className={`w-full py-4 rounded-xl font-bold text-lg transition-all ${
-            acknowledged
-              ? 'bg-linear-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 shadow-lg shadow-amber-500/25'
-              : 'bg-slate-800 text-slate-500 cursor-not-allowed'
-          }`}
+          className="btn-primary w-full py-4 text-lg"
         >
           Continue to Stashu
         </button>

--- a/client/src/components/RestorePage.tsx
+++ b/client/src/components/RestorePage.tsx
@@ -68,11 +68,7 @@ export function RestorePage() {
           <button
             onClick={handleRestore}
             disabled={loading || !nsec.trim()}
-            className={`w-full py-4 rounded-xl font-bold text-lg transition-all ${
-              loading || !nsec.trim()
-                ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
-                : 'bg-linear-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 shadow-lg shadow-amber-500/25'
-            }`}
+            className="btn-primary w-full py-4 text-lg"
           >
             {loading ? 'Restoring...' : 'Restore Account'}
           </button>

--- a/client/src/components/SellPage.tsx
+++ b/client/src/components/SellPage.tsx
@@ -1,12 +1,202 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState, type SyntheticEvent } from 'react';
 import { Link } from 'react-router-dom';
-import { PartyPopper, Squirrel } from 'lucide-react';
+import { FileText, PartyPopper, ShieldCheck, SlidersHorizontal, Squirrel } from 'lucide-react';
 import { FileUploader } from './FileUploader';
 import { RecoveryTokenModal } from './RecoveryTokenModal';
 import { useToast } from './useToast';
 import { useStash } from '../lib/useStash';
 import { hasAcknowledgedRecovery, getOrCreateIdentity } from '../lib/identity';
 import { copyToClipboard } from '../lib/clipboard';
+import {
+  DEFAULT_TEXT_LINE_LIMIT,
+  DEFAULT_TEXT_MAX_BYTES,
+  DEFAULT_TEXT_MAX_CHARS,
+  DEFAULT_TEXT_PREVIEW_RATIO,
+  MAX_TEXT_PREVIEW_CHARS,
+  generatePreviewFromBytes,
+  generatePreviewFromFile,
+  type GeneratedPreviewPayload,
+  type TextLineLimit,
+} from '../lib/generatedPreview';
+import { decodeTextPreview } from '../lib/verifiedPreview';
+import type { TextPreviewMetadata } from '../../../shared/types';
+
+type PeekMode = 'none' | 'auto' | 'excerpt';
+type PreviewPresetId = 'shorter' | 'standard' | 'larger';
+type QuickExcerptPosition = 'start' | 'middle' | 'end';
+
+interface PreviewPreset {
+  label: string;
+  body: string;
+  lineLimit: TextLineLimit;
+  maxChars: number;
+  maxPreviewRatio: number;
+}
+
+const MAX_EXCERPT_EDITOR_BYTES = 1024 * 1024;
+const QUICK_PEEK_MAX_BYTES = 4 * 1024;
+const LARGE_REVEAL_PERCENT = 15;
+const LARGE_REVEAL_BYTES = 4 * 1024;
+const textEncoder = new TextEncoder();
+
+const PREVIEW_PRESETS: Record<PreviewPresetId, PreviewPreset> = {
+  shorter: {
+    label: 'Shorter',
+    body: 'Best for sensitive files.',
+    lineLimit: 4,
+    maxChars: 800,
+    maxPreviewRatio: 0.05,
+  },
+  standard: {
+    label: 'Standard',
+    body: 'Good default for prompts, notes, and docs.',
+    lineLimit: DEFAULT_TEXT_LINE_LIMIT,
+    maxChars: DEFAULT_TEXT_MAX_CHARS,
+    maxPreviewRatio: DEFAULT_TEXT_PREVIEW_RATIO,
+  },
+  larger: {
+    label: 'Larger',
+    body: 'Shows more before payment.',
+    lineLimit: 20,
+    maxChars: MAX_TEXT_PREVIEW_CHARS,
+    maxPreviewRatio: 0.3,
+  },
+};
+
+function utf8ByteLength(value: string): number {
+  return textEncoder.encode(value).length;
+}
+
+function lineStartBefore(text: string, index: number): number {
+  const newline = text.lastIndexOf('\n', Math.max(0, index - 1));
+  return newline === -1 ? 0 : newline + 1;
+}
+
+function lineStartBeforeLastLines(text: string, lineCount: number): number {
+  let index = text.length;
+  for (let i = 0; i < lineCount; i += 1) {
+    const newline = text.lastIndexOf('\n', Math.max(0, index - 2));
+    if (newline === -1) return 0;
+    index = newline + 1;
+  }
+  return index;
+}
+
+function lineEndAfter(text: string, start: number, lineCount: number): number {
+  let end = start;
+  for (let i = 0; i < lineCount; i += 1) {
+    const newline = text.indexOf('\n', end);
+    if (newline === -1) return text.length;
+
+    if (i === lineCount - 1) {
+      return text[newline - 1] === '\r' ? newline - 1 : newline;
+    }
+
+    end = newline + 1;
+  }
+  return end;
+}
+
+function limitTextByBytes(text: string, maxBytes: number): string {
+  let bytes = 0;
+  let output = '';
+
+  for (const char of text) {
+    const nextBytes = utf8ByteLength(char);
+    if (bytes + nextBytes > maxBytes) break;
+    bytes += nextBytes;
+    output += char;
+  }
+
+  return output;
+}
+
+function limitTextByChars(text: string, maxChars: number): string {
+  return Array.from(text).slice(0, maxChars).join('');
+}
+
+function buildQuickExcerpt(
+  fileText: string,
+  fileSize: number,
+  position: QuickExcerptPosition,
+  preset: PreviewPreset
+): { offset: number; text: string } | null {
+  const budget = Math.max(
+    1,
+    Math.min(QUICK_PEEK_MAX_BYTES, Math.floor(fileSize * preset.maxPreviewRatio))
+  );
+  const start =
+    position === 'start'
+      ? 0
+      : position === 'middle'
+        ? lineStartBefore(fileText, Math.floor(fileText.length / 2))
+        : lineStartBeforeLastLines(fileText, preset.lineLimit);
+  const end = lineEndAfter(fileText, start, preset.lineLimit);
+  const text = limitTextByBytes(
+    limitTextByChars(fileText.slice(start, end), preset.maxChars),
+    budget
+  );
+
+  if (!text.trim()) return null;
+
+  return {
+    offset: utf8ByteLength(fileText.slice(0, start)),
+    text,
+  };
+}
+
+function formatPercent(value: number): string {
+  return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${Math.round((bytes / 1024) * 10) / 10} KB`;
+}
+
+function compactCount(value: number): string {
+  if (value < 10_000) return value.toLocaleString();
+  return Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function textStats(text: string): { bytes: number; chars: number; lines: number } {
+  return {
+    bytes: utf8ByteLength(text),
+    chars: Array.from(text).length,
+    lines: text.length === 0 ? 0 : text.split(/\r\n|\r|\n/).length,
+  };
+}
+
+function getExcerptStats(
+  excerpt: { text: string },
+  fileSize: number,
+  preset: PreviewPreset
+): {
+  bytes: number;
+  chars: number;
+  lines: number;
+  percent: number;
+  byteLimit: number;
+  tooLarge: boolean;
+} {
+  const { bytes, chars, lines } = textStats(excerpt.text);
+  const percent = fileSize > 0 ? Math.round((bytes / fileSize) * 1000) / 10 : 0;
+  const byteLimit = Math.min(DEFAULT_TEXT_MAX_BYTES, Math.floor(fileSize * preset.maxPreviewRatio));
+  const tooLarge =
+    bytes > byteLimit || chars > preset.maxChars || lines > preset.lineLimit || bytes >= fileSize;
+
+  return {
+    bytes,
+    chars,
+    lines,
+    percent,
+    byteLimit,
+    tooLarge,
+  };
+}
 
 // Pre-computed confetti styles (module-level, generated once)
 const CONFETTI_STYLES = Array.from({ length: 40 }, (_, i) => ({
@@ -22,6 +212,18 @@ export function SellPage() {
   const stash = useStash();
   const toast = useToast();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [peekMode, setPeekMode] = useState<PeekMode>('none');
+  const [previewPreset, setPreviewPreset] = useState<PreviewPresetId>('standard');
+  const [showPreviewControls, setShowPreviewControls] = useState(false);
+  const [generatedPreview, setGeneratedPreview] = useState<GeneratedPreviewPayload | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [fileText, setFileText] = useState<string | null>(null);
+  const [quickExcerptPosition, setQuickExcerptPosition] = useState<QuickExcerptPosition | null>(
+    null
+  );
+  const [selectedExcerpt, setSelectedExcerpt] = useState<{ offset: number; text: string } | null>(
+    null
+  );
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
@@ -33,6 +235,298 @@ export function SellPage() {
 
   const handleFileSelect = (file: File) => {
     setSelectedFile(file);
+    setGeneratedPreview(null);
+    setPreviewError(null);
+    setFileText(null);
+    setQuickExcerptPosition(null);
+    setSelectedExcerpt(null);
+    setPeekMode('none');
+    setPreviewPreset('standard');
+    setShowPreviewControls(false);
+  };
+
+  const activePreviewPreset = PREVIEW_PRESETS[previewPreset];
+
+  useEffect(() => {
+    if (!selectedFile) return;
+
+    let cancelled = false;
+
+    if (peekMode === 'excerpt') {
+      if (selectedFile.size > MAX_EXCERPT_EDITOR_BYTES) {
+        queueMicrotask(() => {
+          if (cancelled) return;
+          setGeneratedPreview(null);
+          setFileText(null);
+          setPreviewError('Choose text is available for files up to 1 MB');
+        });
+        return () => {
+          cancelled = true;
+        };
+      }
+
+      selectedFile
+        .text()
+        .then((text) => {
+          if (cancelled) return;
+          setFileText(text);
+          setPreviewError(null);
+        })
+        .catch((error) => {
+          if (cancelled) return;
+          setFileText(null);
+          setPreviewError(error instanceof Error ? error.message : 'Could not read file text');
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    generatePreviewFromFile(selectedFile, {
+      mode: peekMode,
+      lineLimit: activePreviewPreset.lineLimit,
+      maxChars: activePreviewPreset.maxChars,
+      maxPreviewRatio: activePreviewPreset.maxPreviewRatio,
+    })
+      .then((preview) => {
+        if (cancelled) return;
+        setGeneratedPreview(preview);
+        setPreviewError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setGeneratedPreview(null);
+        setPreviewError(error instanceof Error ? error.message : 'Could not generate preview');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedFile, activePreviewPreset, peekMode]);
+
+  const quickExcerpt = useMemo(() => {
+    if (peekMode !== 'excerpt' || !quickExcerptPosition || !fileText || !selectedFile) return null;
+
+    return buildQuickExcerpt(
+      fileText,
+      selectedFile.size,
+      quickExcerptPosition,
+      activePreviewPreset
+    );
+  }, [peekMode, quickExcerptPosition, fileText, selectedFile, activePreviewPreset]);
+
+  const selectedExcerptStats = useMemo(() => {
+    if (!selectedExcerpt || !selectedFile) return null;
+
+    return getExcerptStats(selectedExcerpt, selectedFile.size, activePreviewPreset);
+  }, [selectedExcerpt, selectedFile, activePreviewPreset]);
+
+  const manualPeekTooLarge = Boolean(
+    !quickExcerptPosition && selectedExcerpt && selectedExcerptStats?.tooLarge
+  );
+  const selectedExcerptTooLargeMessage =
+    previewPreset === 'larger'
+      ? "This selection is beyond Stashu's max public preview. Pick less text. The public preview stayed unchanged."
+      : 'This selection reveals too much for the current setting. Pick less text or choose a larger setting in More control. The public preview stayed unchanged.';
+  const activePeekExcerpt = quickExcerptPosition
+    ? quickExcerpt
+    : manualPeekTooLarge
+      ? null
+      : selectedExcerpt;
+
+  useEffect(() => {
+    if (!selectedFile || peekMode !== 'excerpt' || !activePeekExcerpt) {
+      return;
+    }
+
+    let cancelled = false;
+
+    selectedFile
+      .arrayBuffer()
+      .then((content) => {
+        if (cancelled) return;
+        const preview = generatePreviewFromBytes(
+          {
+            fileName: selectedFile.name,
+            fileType: selectedFile.type,
+            fileSize: selectedFile.size,
+            content,
+          },
+          {
+            mode: 'excerpt',
+            lineLimit: activePreviewPreset.lineLimit,
+            maxChars: activePreviewPreset.maxChars,
+            maxPreviewRatio: activePreviewPreset.maxPreviewRatio,
+            excerpt: activePeekExcerpt,
+          }
+        );
+        setGeneratedPreview(preview);
+        setPreviewError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setGeneratedPreview(null);
+        setPreviewError(error instanceof Error ? error.message : 'Could not generate peek');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedFile, peekMode, activePeekExcerpt, activePreviewPreset]);
+
+  const previewText = useMemo(
+    () => (generatedPreview ? decodeTextPreview(generatedPreview) : undefined),
+    [generatedPreview]
+  );
+
+  const previewStats = useMemo(() => {
+    if (!generatedPreview || generatedPreview.kind !== 'text-peek') return null;
+
+    const metadata = generatedPreview.metadata as TextPreviewMetadata;
+    const chars = previewText ? Array.from(previewText).length : 0;
+    const percent =
+      generatedPreview.fileSize > 0
+        ? Math.round((metadata.previewBytes / generatedPreview.fileSize) * 1000) / 10
+        : 0;
+
+    return {
+      bytes: metadata.previewBytes,
+      chars,
+      lines: metadata.linesIncluded,
+      percent,
+    };
+  }, [generatedPreview, previewText]);
+
+  const liveExcerptPreviewText =
+    peekMode === 'excerpt' && activePeekExcerpt ? activePeekExcerpt.text : undefined;
+  const liveExcerptPreviewStats = useMemo(() => {
+    if (!liveExcerptPreviewText || !selectedFile) return null;
+
+    const stats = textStats(liveExcerptPreviewText);
+
+    return {
+      bytes: stats.bytes,
+      chars: stats.chars,
+      lines: stats.lines,
+      percent:
+        selectedFile.size > 0 ? Math.round((stats.bytes / selectedFile.size) * 1000) / 10 : 0,
+    };
+  }, [liveExcerptPreviewText, selectedFile]);
+  const displayPreviewText = manualPeekTooLarge
+    ? previewText
+    : (liveExcerptPreviewText ?? previewText);
+  const displayPreviewStats = manualPeekTooLarge
+    ? previewStats
+    : (liveExcerptPreviewStats ?? previewStats);
+  const largeReveal =
+    displayPreviewStats &&
+    (displayPreviewStats.percent >= LARGE_REVEAL_PERCENT ||
+      displayPreviewStats.bytes > LARGE_REVEAL_BYTES);
+  const previewCardTitle = manualPeekTooLarge
+    ? 'Previous public preview'
+    : peekMode === 'auto'
+      ? 'Quick preview'
+      : 'Public preview';
+  const previewCardHint = manualPeekTooLarge
+    ? 'Your latest selection was too large, so Stashu kept the last valid preview.'
+    : peekMode === 'auto'
+      ? 'For text files, Stashu uses the start of the file. Use the Choose text option for a different sample.'
+      : quickExcerptPosition
+        ? `This sample uses the ${quickExcerptPosition} of the file. Select text for exact control.`
+        : 'This exact text will be public before payment.';
+  const fileSummaryReason =
+    generatedPreview?.kind === 'file-summary'
+      ? (generatedPreview.metadata as { reason?: string }).reason
+      : null;
+  const fileSummaryText =
+    fileSummaryReason === 'unsupported-type'
+      ? {
+          title: 'No text preview for this file.',
+          body: 'The file will still get a commitment check after unlock.',
+        }
+      : fileSummaryReason === 'decode-failed'
+        ? {
+            title: 'Could not read this as text.',
+            body: 'The file will still get a commitment check after unlock.',
+          }
+        : fileSummaryReason === 'preview-would-reveal-file'
+          ? {
+              title: 'Preview skipped for this file.',
+              body: 'Showing a sample would reveal too much of the file.',
+            }
+          : null;
+
+  const peekModeInfo = useMemo(() => {
+    if (peekMode === 'auto') {
+      return {
+        title: 'Uses the start of the file',
+        body: 'Quick option for text files. Use Choose text if the start gives away too much.',
+        tone: 'public',
+      };
+    }
+
+    if (peekMode === 'excerpt') {
+      return {
+        title: 'You choose the text',
+        body: 'Only the chosen text becomes public. Stashu proves it is inside the file.',
+        tone: 'public',
+      };
+    }
+
+    return {
+      title: 'Most private',
+      body: 'Nothing from the file is shown before payment.',
+      tone: 'private',
+    };
+  }, [peekMode]);
+
+  const commitExcerptSelection = (input: HTMLTextAreaElement) => {
+    const start = input.selectionStart ?? 0;
+    const end = input.selectionEnd ?? 0;
+
+    // Clicking controls can collapse the browser selection. Keep the last
+    // valid public preview instead of clearing it.
+    if (!fileText || end <= start) return;
+
+    const excerpt = {
+      offset: utf8ByteLength(fileText.slice(0, start)),
+      text: fileText.slice(start, end),
+    };
+    const stats = selectedFile
+      ? getExcerptStats(excerpt, selectedFile.size, activePreviewPreset)
+      : null;
+
+    setSelectedExcerpt(excerpt);
+    setQuickExcerptPosition(null);
+
+    if (stats?.tooLarge) {
+      setPreviewError(null);
+      return;
+    }
+
+    setGeneratedPreview(null);
+    setPreviewError(null);
+  };
+
+  const handleExcerptSelectionCommit = (event: SyntheticEvent<HTMLTextAreaElement>) => {
+    commitExcerptSelection(event.currentTarget);
+  };
+
+  const applyQuickExcerpt = (position: QuickExcerptPosition) => {
+    if (!fileText || !selectedFile) return;
+
+    const excerpt = buildQuickExcerpt(fileText, selectedFile.size, position, activePreviewPreset);
+
+    if (!excerpt) {
+      setPreviewError('Could not find text for that quick peek');
+      return;
+    }
+
+    setSelectedExcerpt(null);
+    setQuickExcerptPosition(position);
+    setGeneratedPreview(null);
+    setPreviewError(null);
   };
 
   const handleSubmit = async () => {
@@ -45,10 +539,25 @@ export function SellPage() {
     }
     setPriceError(null);
 
+    if (manualPeekTooLarge) {
+      setPreviewError('Pick less text or choose Larger before publishing');
+      return;
+    }
+
+    if (peekMode === 'excerpt' && !activePeekExcerpt) {
+      setPreviewError('Choose text or switch to Auto preview');
+      return;
+    }
+
     await stash.createStash(selectedFile, {
       title,
       description: description || undefined,
       priceSats,
+      peekMode,
+      previewLineLimit: activePreviewPreset.lineLimit,
+      previewMaxChars: activePreviewPreset.maxChars,
+      previewRatio: activePreviewPreset.maxPreviewRatio,
+      peekExcerpt: activePeekExcerpt || undefined,
     });
   };
 
@@ -133,6 +642,254 @@ export function SellPage() {
         <div className="mb-8">
           <FileUploader onFileSelect={handleFileSelect} disabled={stash.status !== 'idle'} />
         </div>
+
+        {selectedFile && (
+          <div className="soft-appear mb-8 bg-slate-800/50 border border-slate-700 rounded-2xl p-5">
+            <div className="mb-4">
+              <div className="flex items-center gap-2">
+                <ShieldCheck className="w-5 h-5 text-emerald-400" />
+                <h2 className="text-white font-semibold">Preview for buyers</h2>
+              </div>
+              <p className="mt-1 text-sm text-slate-400">
+                Choose whether buyers can see a verified sample before paying.
+              </p>
+            </div>
+
+            <div className="mb-4 grid gap-2 sm:grid-cols-3">
+              {[
+                {
+                  label: 'No preview',
+                  body: 'Most private',
+                  value: 'none' as const,
+                },
+                {
+                  label: 'Quick preview',
+                  body: 'Start of file',
+                  value: 'auto' as const,
+                },
+                {
+                  label: 'Choose text',
+                  body: 'You pick it',
+                  value: 'excerpt' as const,
+                },
+              ].map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    if (option.value === peekMode) return;
+
+                    setPeekMode(option.value);
+                    setGeneratedPreview(null);
+                    setPreviewError(null);
+                    if (option.value !== 'excerpt') {
+                      setFileText(null);
+                      setQuickExcerptPosition(null);
+                      setSelectedExcerpt(null);
+                    }
+                  }}
+                  className={`rounded-xl border px-3 py-3 text-left transition-colors ${
+                    peekMode === option.value
+                      ? 'border-orange-500 bg-orange-500/10 text-white'
+                      : 'border-slate-700 bg-slate-900/40 text-slate-400 hover:border-slate-500 hover:text-white'
+                  }`}
+                >
+                  <span className="block text-sm font-semibold">{option.label}</span>
+                  <span className="mt-1 block text-xs opacity-75">{option.body}</span>
+                </button>
+              ))}
+            </div>
+
+            <div
+              className={`soft-surface mb-4 rounded-xl border p-3 ${
+                peekModeInfo.tone === 'public'
+                  ? 'border-amber-500/30 bg-amber-500/10'
+                  : 'border-slate-700 bg-slate-950/50'
+              }`}
+            >
+              <p
+                className={`text-sm font-medium ${
+                  peekModeInfo.tone === 'public' ? 'text-amber-200' : 'text-slate-200'
+                }`}
+              >
+                {peekModeInfo.title}
+              </p>
+              <p
+                className={`mt-1 text-xs ${
+                  peekModeInfo.tone === 'public' ? 'text-amber-100/70' : 'text-slate-500'
+                }`}
+              >
+                {peekModeInfo.body}
+              </p>
+            </div>
+
+            <div>
+              {peekMode !== 'none' && (
+                <div className="mb-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowPreviewControls((value) => !value)}
+                    className="inline-flex items-center gap-2 text-sm font-medium text-slate-400 transition-colors hover:text-white"
+                  >
+                    <SlidersHorizontal className="h-4 w-4" />
+                    More control
+                  </button>
+
+                  {showPreviewControls && (
+                    <div className="soft-appear mt-3 rounded-xl border border-slate-700 bg-slate-950/40 p-3">
+                      <div className="grid gap-2 sm:grid-cols-3">
+                        {(Object.keys(PREVIEW_PRESETS) as PreviewPresetId[]).map((presetId) => {
+                          const preset = PREVIEW_PRESETS[presetId];
+                          return (
+                            <button
+                              key={presetId}
+                              type="button"
+                              onClick={() => {
+                                if (presetId === previewPreset) return;
+
+                                setPreviewPreset(presetId);
+                                setPreviewError(null);
+                              }}
+                              className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                                previewPreset === presetId
+                                  ? 'border-orange-500 bg-orange-500/10 text-white'
+                                  : 'border-slate-700 text-slate-400 hover:border-slate-500 hover:text-white'
+                              }`}
+                            >
+                              <span className="block text-sm font-semibold">{preset.label}</span>
+                              <span className="mt-1 block text-xs opacity-75">{preset.body}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <p className="mt-3 text-xs text-slate-500">
+                        {activePreviewPreset.label}: up to {activePreviewPreset.lineLimit} lines,{' '}
+                        {activePreviewPreset.maxChars.toLocaleString()} chars, or{' '}
+                        {formatPercent(activePreviewPreset.maxPreviewRatio * 100)} of this file.
+                        Safety cap: {formatBytes(DEFAULT_TEXT_MAX_BYTES)}.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {peekMode === 'excerpt' && fileText !== null && (
+                <div className="soft-appear">
+                  <p className="mb-2 text-xs text-slate-500">
+                    Pick a quick sample, or select text below. The public preview updates when you
+                    finish selecting.
+                  </p>
+                  <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+                    Quick sample
+                  </p>
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    {[
+                      { label: 'Start', value: 'start' as const },
+                      { label: 'Middle', value: 'middle' as const },
+                      { label: 'End', value: 'end' as const },
+                    ].map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => applyQuickExcerpt(option.value)}
+                        className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+                          quickExcerptPosition === option.value
+                            ? 'border-orange-500 bg-orange-500/10 text-white'
+                            : 'border-slate-700 text-slate-300 hover:border-slate-500 hover:text-white'
+                        }`}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                  <textarea
+                    value={fileText}
+                    onMouseUp={handleExcerptSelectionCommit}
+                    onKeyUp={handleExcerptSelectionCommit}
+                    onTouchEnd={handleExcerptSelectionCommit}
+                    readOnly
+                    rows={8}
+                    className="mb-4 w-full resize-none rounded-xl border border-slate-700 bg-slate-950/70 p-4 text-sm text-slate-200 selection:bg-orange-500/30 selection:text-orange-50 focus:border-orange-500 focus:outline-none"
+                    spellCheck={false}
+                  />
+                  {selectedExcerptStats?.tooLarge && (
+                    <p className="soft-appear mb-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-xs text-rose-200">
+                      {selectedExcerptTooLargeMessage}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {previewError ? (
+                <p className="text-red-400 text-sm">{previewError}</p>
+              ) : displayPreviewText !== undefined ? (
+                <>
+                  <div className="soft-appear rounded-lg border border-orange-500/25 bg-orange-500/10 p-3">
+                    <div className="mb-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-orange-200/80">
+                        {previewCardTitle}
+                      </p>
+                      <p className="mt-1 text-xs text-orange-50/60">{previewCardHint}</p>
+                    </div>
+                    <pre className="h-48 overflow-auto whitespace-pre-wrap break-words text-sm leading-relaxed text-orange-50/90">
+                      {displayPreviewText || 'Empty preview'}
+                    </pre>
+                  </div>
+                  <div className="pt-3">
+                    {displayPreviewStats ? (
+                      <p className="grid grid-cols-[4rem_5.5rem_6rem] gap-2 text-xs text-slate-500">
+                        <span className="tabular-nums">
+                          {displayPreviewStats.lines} line
+                          {displayPreviewStats.lines === 1 ? '' : 's'}
+                        </span>
+                        <span className="tabular-nums">
+                          {compactCount(displayPreviewStats.chars)} chars
+                        </span>
+                        <span className="tabular-nums">
+                          {formatPercent(displayPreviewStats.percent)} public
+                        </span>
+                      </p>
+                    ) : null}
+                    {largeReveal && (
+                      <p className="soft-appear mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-100">
+                        This is a larger public peek. Anyone with the stash link can read it before
+                        paying.
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : peekMode === 'auto' && fileSummaryText ? (
+                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                  <div>
+                    <p className="text-slate-300 text-sm">{fileSummaryText.title}</p>
+                    <p className="text-slate-500 text-xs mt-1">{fileSummaryText.body}</p>
+                  </div>
+                </div>
+              ) : peekMode === 'auto' ? null : peekMode === 'excerpt' ? (
+                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                  <div>
+                    <p className="text-slate-300 text-sm">Pick text to show buyers.</p>
+                    <p className="text-slate-500 text-xs mt-1">
+                      Use Start, Middle, End, or select text yourself.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                  <div>
+                    <p className="text-slate-300 text-sm">No public peek will be shown.</p>
+                    <p className="text-slate-500 text-xs mt-1">
+                      The file will still get a commitment check after unlock.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* Form Fields */}
         <div className="space-y-6 mb-8">

--- a/client/src/components/SellPage.tsx
+++ b/client/src/components/SellPage.tsx
@@ -596,8 +596,7 @@ export function SellPage() {
                   toast.showToast('Failed to copy link', 'error');
                 }
               }}
-              className="py-3 px-6 bg-orange-500 hover:bg-orange-600 
-                       text-white font-semibold rounded-xl transition-colors"
+              className="btn-primary px-6 py-3"
             >
               Copy Link
             </button>
@@ -962,9 +961,7 @@ export function SellPage() {
         <button
           onClick={handleSubmit}
           disabled={!selectedFile || !title || !price || stash.status !== 'idle'}
-          className="w-full py-4 px-6 bg-orange-500 hover:bg-orange-600 
-                   text-white font-bold text-lg rounded-xl transition-colors
-                   disabled:opacity-50 disabled:cursor-not-allowed"
+          className="btn-primary w-full px-6 py-4 text-lg"
         >
           {stash.status === 'idle' ? (
             <>

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -227,7 +227,7 @@ export function SettingsPage() {
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
-              className={`flex-1 py-2.5 px-4 rounded-lg text-sm font-medium transition-colors ${
+              className={`flex-1 py-2.5 px-4 rounded-lg text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                 activeTab === tab.id
                   ? 'bg-slate-700 text-white'
                   : 'text-slate-400 hover:text-slate-300'
@@ -238,428 +238,432 @@ export function SettingsPage() {
           ))}
         </div>
 
-        {/* Payments Tab */}
-        {activeTab === 'payments' && (
-          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-            <div className="flex items-center gap-2 mb-2">
-              <Zap className="w-5 h-5 text-amber-400" />
-              <h2 className="text-lg font-semibold text-white">Auto-Settlement</h2>
-              {isAutoSettleActive ? (
-                <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
-                  Active
-                </span>
-              ) : (
-                <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-400 border border-slate-700/50">
-                  Disabled
-                </span>
-              )}
-            </div>
-            <p className="text-slate-400 text-sm mb-5">
-              Automatically withdraw earnings to your Lightning wallet when your balance reaches the
-              threshold. Set it once, earn passively.
-            </p>
-
-            {loadingSettings ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+        <div className="min-h-[620px]">
+          {/* Payments Tab */}
+          {activeTab === 'payments' && (
+            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+              <div className="flex items-center gap-2 mb-2">
+                <Zap className="w-5 h-5 text-amber-400" />
+                <h2 className="text-lg font-semibold text-white">Auto-Settlement</h2>
+                {isAutoSettleActive ? (
+                  <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
+                    Active
+                  </span>
+                ) : (
+                  <span className="ml-auto text-xs font-medium px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-400 border border-slate-700/50">
+                    Disabled
+                  </span>
+                )}
               </div>
-            ) : (
-              <>
-                {/* Lightning Address */}
-                <div className="mb-5">
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
-                    Lightning Address
-                  </label>
-                  <input
-                    type="text"
-                    value={lnAddress}
-                    onChange={(e) => {
-                      setLnAddress(e.target.value);
-                      setSettingsChanged(true);
-                    }}
-                    placeholder="you@your-wallet.com"
-                    className="w-full bg-slate-950 border border-slate-700 rounded-xl p-4 text-amber-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-amber-500"
-                  />
-                  <p className="text-slate-500 text-xs mt-1.5 flex items-start gap-1">
-                    <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500/60" />
-                    Use an always-online wallet (e.g. Alby, WoS, Coinos) for reliable
-                    auto-settlement. Self-custodial mobile wallets may miss payments when offline.
-                  </p>
-                </div>
+              <p className="text-slate-400 text-sm mb-5">
+                Automatically withdraw earnings to your Lightning wallet when your balance reaches
+                the threshold. Set it once, earn passively.
+              </p>
 
-                {/* Threshold */}
-                <div className="mb-5">
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
-                    Auto-withdraw when balance reaches
-                  </label>
-                  <div className="flex items-center gap-3 mb-3">
+              {loadingSettings ? (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+                </div>
+              ) : (
+                <>
+                  {/* Lightning Address */}
+                  <div className="mb-5">
+                    <label className="block text-sm font-medium text-slate-300 mb-2">
+                      Lightning Address
+                    </label>
                     <input
-                      type="number"
-                      value={threshold || ''}
+                      type="text"
+                      value={lnAddress}
                       onChange={(e) => {
-                        setThreshold(Math.max(0, parseInt(e.target.value) || 0));
+                        setLnAddress(e.target.value);
                         setSettingsChanged(true);
                       }}
-                      placeholder="0"
-                      min="0"
-                      className="w-32 bg-slate-950 border border-slate-700 rounded-xl p-3 text-white text-sm font-mono focus:outline-none focus:border-amber-500"
+                      placeholder="you@your-wallet.com"
+                      className="w-full bg-slate-950 border border-slate-700 rounded-xl p-4 text-amber-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-amber-500"
                     />
-                    <span className="text-slate-400 text-sm">sats</span>
+                    <p className="text-slate-500 text-xs mt-1.5 flex items-start gap-1">
+                      <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500/60" />
+                      Use an always-online wallet (e.g. Alby, WoS, Coinos) for reliable
+                      auto-settlement. Self-custodial mobile wallets may miss payments when offline.
+                    </p>
                   </div>
 
-                  {/* Preset buttons */}
-                  <div className="flex flex-wrap gap-2">
-                    {thresholdPresets.map((preset) => (
-                      <button
-                        key={preset}
-                        onClick={() => {
-                          setThreshold(preset);
+                  {/* Threshold */}
+                  <div className="mb-5">
+                    <label className="block text-sm font-medium text-slate-300 mb-2">
+                      Auto-withdraw when balance reaches
+                    </label>
+                    <div className="flex items-center gap-3 mb-3">
+                      <input
+                        type="number"
+                        value={threshold || ''}
+                        onChange={(e) => {
+                          setThreshold(Math.max(0, parseInt(e.target.value) || 0));
                           setSettingsChanged(true);
                         }}
-                        className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                          threshold === preset
-                            ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
-                            : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
-                        }`}
-                      >
-                        {preset.toLocaleString()} sats
-                      </button>
-                    ))}
+                        placeholder="0"
+                        min="0"
+                        className="w-32 bg-slate-950 border border-slate-700 rounded-xl p-3 text-white text-sm font-mono focus:outline-none focus:border-amber-500"
+                      />
+                      <span className="text-slate-400 text-sm">sats</span>
+                    </div>
+
+                    {/* Preset buttons */}
+                    <div className="flex flex-wrap gap-2">
+                      {thresholdPresets.map((preset) => (
+                        <button
+                          key={preset}
+                          onClick={() => {
+                            setThreshold(preset);
+                            setSettingsChanged(true);
+                          }}
+                          className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                            threshold === preset
+                              ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30'
+                              : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                          }`}
+                        >
+                          {preset.toLocaleString()} sats
+                        </button>
+                      ))}
+                    </div>
+                    {threshold > 0 && (
+                      <p className="text-slate-500 text-xs mt-2">
+                        When balance reaches {threshold.toLocaleString()} sats, all earnings are
+                        withdrawn minus the network routing fee. If withdrawal fails (e.g. wallet
+                        offline), tokens stay safe and retry on the next payment.
+                      </p>
+                    )}
                   </div>
-                  {threshold > 0 && (
-                    <p className="text-slate-500 text-xs mt-2">
-                      When balance reaches {threshold.toLocaleString()} sats, all earnings are
-                      withdrawn minus the network routing fee. If withdrawal fails (e.g. wallet
-                      offline), tokens stay safe and retry on the next payment.
-                    </p>
-                  )}
-                </div>
 
-                {/* Save button */}
-                <button
-                  onClick={handleSaveSettings}
-                  disabled={saving || !settingsChanged}
-                  className={`flex items-center gap-2 py-2.5 px-5 rounded-xl font-semibold text-sm transition-all ${
-                    saving || !settingsChanged
-                      ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
-                      : 'bg-amber-500 hover:bg-amber-600 text-white'
-                  }`}
-                >
-                  {saving ? (
-                    <>
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                      Saving...
-                    </>
-                  ) : (
-                    <>
-                      <Save className="w-4 h-4" />
-                      Save Settings
-                    </>
-                  )}
-                </button>
-                {isAutoSettleActive && (
-                  <p className="text-slate-500 text-xs mt-2">
-                    To disable, clear the Lightning address and save.
-                  </p>
-                )}
-              </>
-            )}
-          </div>
-        )}
-
-        {/* Account Tab */}
-        {activeTab === 'account' && (
-          <>
-            {/* Public Storefront */}
-            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-xl bg-violet-500/20 flex items-center justify-center">
-                    <Store className="w-5 h-5 text-violet-400" />
-                  </div>
-                  <div>
-                    <h2 className="text-lg font-semibold text-white">Public Storefront</h2>
-                    <p className="text-slate-400 text-sm">
-                      Let anyone browse all your stashes from one link.
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={handleToggleStorefront}
-                  disabled={savingStorefront || loadingSettings}
-                  className={`relative w-12 h-7 rounded-full transition-colors ${
-                    savingStorefront ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${storefrontEnabled ? 'bg-violet-500' : 'bg-slate-600'}`}
-                >
-                  <span
-                    className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full transition-transform ${
-                      storefrontEnabled ? 'translate-x-5' : 'translate-x-0'
-                    }`}
-                  />
-                </button>
-              </div>
-              <div className="mt-4 pt-4 border-t border-slate-700/50">
-                {storefrontEnabled && (
-                  <p className="text-slate-500 text-sm mb-3">
-                    Your storefront:{' '}
-                    <button
-                      onClick={async () => {
-                        const url = `${window.location.origin}/p/${identity.npub}`;
-                        const success = await copyToClipboard(url);
-                        if (success) {
-                          toast.showToast('Storefront link copied!', 'success');
-                        }
-                      }}
-                      className="text-violet-400 hover:text-violet-300 underline transition-colors"
-                    >
-                      {window.location.origin}/p/{identity.npub.slice(0, 12)}…
-                    </button>
-                  </p>
-                )}
-                <div className="p-3 bg-slate-700/30 border border-slate-700/50 rounded-lg">
-                  <p className="text-slate-400 text-xs">
-                    Your storefront URL contains your Nostr public key. Sharing it publicly will
-                    link your Nostr identity to your Stashu presence.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            {/* Public Key */}
-            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-              <div className="flex items-center gap-2 mb-4">
-                <Shield className="w-5 h-5 text-indigo-400" />
-                <h2 className="text-lg font-semibold text-white">Public Key</h2>
-              </div>
-              <p className="text-slate-400 text-sm mb-4">
-                Your public identity on Nostr. Safe to share — this is how buyers' payments are
-                linked to you.
-              </p>
-              <div className="flex items-center gap-3">
-                <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-indigo-300 break-all select-all">
-                  {identity.npub}
-                </div>
-                <button
-                  onClick={() => handleCopy(identity.npub, 'Public key')}
-                  className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
-                  title="Copy public key"
-                >
-                  {copiedField === 'Public key' ? (
-                    <Check className="w-5 h-5 text-emerald-400" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-slate-300" />
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {/* Recovery Token (nsec) */}
-            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-              <div className="flex items-center gap-2 mb-4">
-                <AlertTriangle className="w-5 h-5 text-amber-400" />
-                <h2 className="text-lg font-semibold text-white">Recovery Token</h2>
-              </div>
-              <p className="text-slate-400 text-sm mb-4">
-                Your secret key. <strong className="text-rose-400">Never share this.</strong> Anyone
-                with this token can access your earnings.
-              </p>
-
-              <div className="flex items-center gap-3 mb-3">
-                <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-amber-400 break-all">
-                  {nsecRevealed
-                    ? identity.nsec
-                    : '••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••'}
-                </div>
-                <button
-                  onClick={() => handleCopy(identity.nsec, 'Recovery token')}
-                  className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
-                  title="Copy recovery token"
-                >
-                  {copiedField === 'Recovery token' ? (
-                    <Check className="w-5 h-5 text-emerald-400" />
-                  ) : (
-                    <Copy className="w-5 h-5 text-slate-300" />
-                  )}
-                </button>
-              </div>
-
-              <button
-                onClick={() => setNsecRevealed(!nsecRevealed)}
-                className="text-sm text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1.5"
-              >
-                {nsecRevealed ? (
-                  <>
-                    <EyeOff className="w-4 h-4" />
-                    Hide token
-                  </>
-                ) : (
-                  <>
-                    <Eye className="w-4 h-4" />
-                    Reveal token
-                  </>
-                )}
-              </button>
-            </div>
-
-            {/* Danger Zone */}
-            <div className="bg-rose-500/5 border border-rose-500/20 rounded-2xl p-6">
-              <div className="flex items-center gap-2 mb-4">
-                <Trash2 className="w-5 h-5 text-rose-400" />
-                <h2 className="text-lg font-semibold text-rose-300">Danger Zone</h2>
-              </div>
-              <p className="text-slate-400 text-sm mb-4">
-                Clear your identity from this device. Make sure you've saved your recovery token
-                first — <strong className="text-rose-400">this cannot be undone</strong>.
-              </p>
-
-              {!showClearConfirm ? (
-                <button
-                  onClick={() => setShowClearConfirm(true)}
-                  className="py-3 px-6 bg-rose-500/10 border border-rose-500/30 text-rose-400 font-semibold rounded-xl hover:bg-rose-500/20 transition-colors"
-                >
-                  Clear Identity
-                </button>
-              ) : (
-                <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4">
-                  <p className="text-rose-300 text-sm font-medium mb-4">
-                    Are you sure? This will remove your keys from this device.
-                  </p>
-                  <div className="flex gap-3">
-                    <button
-                      onClick={handleClearIdentity}
-                      className="py-2 px-5 bg-rose-500 hover:bg-rose-600 text-white font-semibold rounded-lg transition-colors"
-                    >
-                      Yes, Clear
-                    </button>
-                    <button
-                      onClick={() => setShowClearConfirm(false)}
-                      className="py-2 px-5 bg-slate-700 hover:bg-slate-600 text-slate-300 font-semibold rounded-lg transition-colors"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          </>
-        )}
-
-        {/* Advanced Tab */}
-        {activeTab === 'advanced' && (
-          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
-            <div className="flex items-center gap-2 mb-2">
-              <Server className="w-5 h-5 text-cyan-400" />
-              <h2 className="text-lg font-semibold text-white">Blossom Server</h2>
-            </div>
-            <p className="text-slate-400 text-sm mb-5">
-              Choose where your encrypted files are stored. Use the toggle below to control backup
-              mirroring.
-            </p>
-
-            {/* Preset server buttons */}
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-slate-300 mb-2">
-                Select a server
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {PRESET_BLOSSOM_SERVERS.map((server) => (
+                  {/* Save button */}
                   <button
-                    key={server.url}
-                    onClick={() => handleSelectBlossomPreset(server.url)}
-                    className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                      blossomServer === server.url
-                        ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
-                        : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                    onClick={handleSaveSettings}
+                    disabled={saving || !settingsChanged}
+                    className={`flex items-center gap-2 py-2.5 px-5 rounded-xl font-semibold text-sm transition-all ${
+                      saving || !settingsChanged
+                        ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
+                        : 'bg-amber-500 hover:bg-amber-600 text-white'
                     }`}
                   >
-                    {server.label}
+                    {saving ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Save className="w-4 h-4" />
+                        Save Settings
+                      </>
+                    )}
                   </button>
-                ))}
-              </div>
+                  {isAutoSettleActive && (
+                    <p className="text-slate-500 text-xs mt-2">
+                      To disable, clear the Lightning address and save.
+                    </p>
+                  )}
+                </>
+              )}
             </div>
+          )}
 
-            {/* Custom URL input */}
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-slate-300 mb-2">
-                Or use a custom server
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  type="text"
-                  value={customBlossomUrl}
-                  onChange={(e) => {
-                    setCustomBlossomUrl(e.target.value);
-                    setBlossomUrlError('');
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleCustomBlossomSubmit();
-                  }}
-                  onBlur={() => {
-                    if (customBlossomUrl.trim()) handleCustomBlossomSubmit();
-                  }}
-                  placeholder="your-blossom-server.com"
-                  className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-3 text-cyan-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-cyan-500"
-                />
-              </div>
-              {blossomUrlError && <p className="text-rose-400 text-xs mt-1.5">{blossomUrlError}</p>}
-              <p className="text-slate-500 text-xs mt-1.5">
-                Most public Blossom servers don't support encrypted file uploads. Only add a server
-                you've tested.
-              </p>
-            </div>
-
-            {/* Current server indicator */}
-            <div className="bg-slate-950/50 border border-slate-700/50 rounded-xl p-3 mb-4">
-              <p className="text-slate-500 text-xs">
-                Current: <span className="text-cyan-400 font-mono">{blossomServer}</span>
-              </p>
-            </div>
-
-            {/* Mirroring toggle — only show when there are backup servers to mirror to */}
-            {PRESET_BLOSSOM_SERVERS.filter((s) => s.url !== blossomServer).length > 0 && (
-              <div className="flex items-center justify-between py-3 border-t border-slate-700/50 mt-2 mb-3">
-                <div>
-                  <p className="text-sm font-medium text-slate-300">Mirror to backup servers</p>
-                  <p className="text-slate-500 text-xs mt-0.5">
-                    Copies your file to other Blossom servers so buyers can download even if your
-                    primary server is down.
-                  </p>
+          {/* Account Tab */}
+          {activeTab === 'account' && (
+            <>
+              {/* Public Storefront */}
+              <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-xl bg-violet-500/20 flex items-center justify-center">
+                      <Store className="w-5 h-5 text-violet-400" />
+                    </div>
+                    <div>
+                      <h2 className="text-lg font-semibold text-white">Public Storefront</h2>
+                      <p className="text-slate-400 text-sm">
+                        Let anyone browse all your stashes from one link.
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={handleToggleStorefront}
+                    disabled={savingStorefront || loadingSettings}
+                    className={`relative w-12 h-7 rounded-full transition-colors ${
+                      savingStorefront ? 'opacity-50 cursor-not-allowed' : ''
+                    } ${storefrontEnabled ? 'bg-violet-500' : 'bg-slate-600'}`}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full transition-transform ${
+                        storefrontEnabled ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
                 </div>
+                <div className="mt-4 pt-4 border-t border-slate-700/50">
+                  {storefrontEnabled && (
+                    <p className="text-slate-500 text-sm mb-3">
+                      Your storefront:{' '}
+                      <button
+                        onClick={async () => {
+                          const url = `${window.location.origin}/p/${identity.npub}`;
+                          const success = await copyToClipboard(url);
+                          if (success) {
+                            toast.showToast('Storefront link copied!', 'success');
+                          }
+                        }}
+                        className="text-violet-400 hover:text-violet-300 underline transition-colors"
+                      >
+                        {window.location.origin}/p/{identity.npub.slice(0, 12)}…
+                      </button>
+                    </p>
+                  )}
+                  <div className="p-3 bg-slate-700/30 border border-slate-700/50 rounded-lg">
+                    <p className="text-slate-400 text-xs">
+                      Your storefront URL contains your Nostr public key. Sharing it publicly will
+                      link your Nostr identity to your Stashu presence.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Public Key */}
+              <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+                <div className="flex items-center gap-2 mb-4">
+                  <Shield className="w-5 h-5 text-indigo-400" />
+                  <h2 className="text-lg font-semibold text-white">Public Key</h2>
+                </div>
+                <p className="text-slate-400 text-sm mb-4">
+                  Your public identity on Nostr. Safe to share — this is how buyers' payments are
+                  linked to you.
+                </p>
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-indigo-300 break-all select-all">
+                    {identity.npub}
+                  </div>
+                  <button
+                    onClick={() => handleCopy(identity.npub, 'Public key')}
+                    className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
+                    title="Copy public key"
+                  >
+                    {copiedField === 'Public key' ? (
+                      <Check className="w-5 h-5 text-emerald-400" />
+                    ) : (
+                      <Copy className="w-5 h-5 text-slate-300" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {/* Recovery Token (nsec) */}
+              <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+                <div className="flex items-center gap-2 mb-4">
+                  <AlertTriangle className="w-5 h-5 text-amber-400" />
+                  <h2 className="text-lg font-semibold text-white">Recovery Token</h2>
+                </div>
+                <p className="text-slate-400 text-sm mb-4">
+                  Your secret key. <strong className="text-rose-400">Never share this.</strong>{' '}
+                  Anyone with this token can access your earnings.
+                </p>
+
+                <div className="flex items-center gap-3 mb-3">
+                  <div className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-4 font-mono text-sm text-amber-400 break-all">
+                    {nsecRevealed
+                      ? identity.nsec
+                      : '••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••'}
+                  </div>
+                  <button
+                    onClick={() => handleCopy(identity.nsec, 'Recovery token')}
+                    className="shrink-0 p-3 bg-slate-700 hover:bg-slate-600 rounded-xl transition-colors"
+                    title="Copy recovery token"
+                  >
+                    {copiedField === 'Recovery token' ? (
+                      <Check className="w-5 h-5 text-emerald-400" />
+                    ) : (
+                      <Copy className="w-5 h-5 text-slate-300" />
+                    )}
+                  </button>
+                </div>
+
                 <button
-                  onClick={() => {
-                    const next = !mirroringEnabled;
-                    setMirroringEnabled(next);
-                    setMirroringEnabledState(next);
-                    toast.showToast(next ? 'Mirroring enabled' : 'Mirroring disabled', 'success');
-                  }}
-                  className={`relative shrink-0 ml-4 w-11 h-6 rounded-full transition-colors ${
-                    mirroringEnabled ? 'bg-cyan-500' : 'bg-slate-600'
-                  }`}
-                  role="switch"
-                  aria-checked={mirroringEnabled}
+                  onClick={() => setNsecRevealed(!nsecRevealed)}
+                  className="text-sm text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1.5"
                 >
-                  <span
-                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
-                      mirroringEnabled ? 'translate-x-5' : 'translate-x-0'
-                    }`}
-                  />
+                  {nsecRevealed ? (
+                    <>
+                      <EyeOff className="w-4 h-4" />
+                      Hide token
+                    </>
+                  ) : (
+                    <>
+                      <Eye className="w-4 h-4" />
+                      Reveal token
+                    </>
+                  )}
                 </button>
               </div>
-            )}
 
-            {/* Hints */}
-            <div className="space-y-1.5">
-              <p className="text-slate-500 text-xs flex items-start gap-1">
-                <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
-                Applies to new stashes only. Existing stashes stay on their original server.
+              {/* Danger Zone */}
+              <div className="bg-rose-500/5 border border-rose-500/20 rounded-2xl p-6">
+                <div className="flex items-center gap-2 mb-4">
+                  <Trash2 className="w-5 h-5 text-rose-400" />
+                  <h2 className="text-lg font-semibold text-rose-300">Danger Zone</h2>
+                </div>
+                <p className="text-slate-400 text-sm mb-4">
+                  Clear your identity from this device. Make sure you've saved your recovery token
+                  first — <strong className="text-rose-400">this cannot be undone</strong>.
+                </p>
+
+                {!showClearConfirm ? (
+                  <button
+                    onClick={() => setShowClearConfirm(true)}
+                    className="py-3 px-6 bg-rose-500/10 border border-rose-500/30 text-rose-400 font-semibold rounded-xl hover:bg-rose-500/20 transition-colors"
+                  >
+                    Clear Identity
+                  </button>
+                ) : (
+                  <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4">
+                    <p className="text-rose-300 text-sm font-medium mb-4">
+                      Are you sure? This will remove your keys from this device.
+                    </p>
+                    <div className="flex gap-3">
+                      <button
+                        onClick={handleClearIdentity}
+                        className="py-2 px-5 bg-rose-500 hover:bg-rose-600 text-white font-semibold rounded-lg transition-colors"
+                      >
+                        Yes, Clear
+                      </button>
+                      <button
+                        onClick={() => setShowClearConfirm(false)}
+                        className="py-2 px-5 bg-slate-700 hover:bg-slate-600 text-slate-300 font-semibold rounded-lg transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Advanced Tab */}
+          {activeTab === 'advanced' && (
+            <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6 mb-6">
+              <div className="flex items-center gap-2 mb-2">
+                <Server className="w-5 h-5 text-cyan-400" />
+                <h2 className="text-lg font-semibold text-white">Blossom Server</h2>
+              </div>
+              <p className="text-slate-400 text-sm mb-5">
+                Choose where your encrypted files are stored. Use the toggle below to control backup
+                mirroring.
               </p>
-              <p className="text-slate-500 text-xs flex items-start gap-1">
-                <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
-                Your server must be publicly accessible for buyers to download files.
-              </p>
+
+              {/* Preset server buttons */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Select a server
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {PRESET_BLOSSOM_SERVERS.map((server) => (
+                    <button
+                      key={server.url}
+                      onClick={() => handleSelectBlossomPreset(server.url)}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                        blossomServer === server.url
+                          ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
+                          : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                      }`}
+                    >
+                      {server.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Custom URL input */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Or use a custom server
+                </label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="text"
+                    value={customBlossomUrl}
+                    onChange={(e) => {
+                      setCustomBlossomUrl(e.target.value);
+                      setBlossomUrlError('');
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleCustomBlossomSubmit();
+                    }}
+                    onBlur={() => {
+                      if (customBlossomUrl.trim()) handleCustomBlossomSubmit();
+                    }}
+                    placeholder="your-blossom-server.com"
+                    className="flex-1 bg-slate-950 border border-slate-700 rounded-xl p-3 text-cyan-400 font-mono text-sm placeholder-slate-600 focus:outline-none focus:border-cyan-500"
+                  />
+                </div>
+                {blossomUrlError && (
+                  <p className="text-rose-400 text-xs mt-1.5">{blossomUrlError}</p>
+                )}
+                <p className="text-slate-500 text-xs mt-1.5">
+                  Most public Blossom servers don't support encrypted file uploads. Only add a
+                  server you've tested.
+                </p>
+              </div>
+
+              {/* Current server indicator */}
+              <div className="bg-slate-950/50 border border-slate-700/50 rounded-xl p-3 mb-4">
+                <p className="text-slate-500 text-xs">
+                  Current: <span className="text-cyan-400 font-mono">{blossomServer}</span>
+                </p>
+              </div>
+
+              {/* Mirroring toggle — only show when there are backup servers to mirror to */}
+              {PRESET_BLOSSOM_SERVERS.filter((s) => s.url !== blossomServer).length > 0 && (
+                <div className="flex items-center justify-between py-3 border-t border-slate-700/50 mt-2 mb-3">
+                  <div>
+                    <p className="text-sm font-medium text-slate-300">Mirror to backup servers</p>
+                    <p className="text-slate-500 text-xs mt-0.5">
+                      Copies your file to other Blossom servers so buyers can download even if your
+                      primary server is down.
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => {
+                      const next = !mirroringEnabled;
+                      setMirroringEnabled(next);
+                      setMirroringEnabledState(next);
+                      toast.showToast(next ? 'Mirroring enabled' : 'Mirroring disabled', 'success');
+                    }}
+                    className={`relative shrink-0 ml-4 w-11 h-6 rounded-full transition-colors ${
+                      mirroringEnabled ? 'bg-cyan-500' : 'bg-slate-600'
+                    }`}
+                    role="switch"
+                    aria-checked={mirroringEnabled}
+                  >
+                    <span
+                      className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                        mirroringEnabled ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              )}
+
+              {/* Hints */}
+              <div className="space-y-1.5">
+                <p className="text-slate-500 text-xs flex items-start gap-1">
+                  <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
+                  Applies to new stashes only. Existing stashes stay on their original server.
+                </p>
+                <p className="text-slate-500 text-xs flex items-start gap-1">
+                  <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-cyan-500/60" />
+                  Your server must be publicly accessible for buyers to download files.
+                </p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -93,10 +93,7 @@ export function SettingsPage() {
           <p className="text-slate-400 mb-8">
             Create a stash first to generate your seller identity.
           </p>
-          <Link
-            to="/sell"
-            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <Link to="/sell" className="btn-primary px-6 py-3">
             Create a Stash
           </Link>
         </div>
@@ -340,11 +337,7 @@ export function SettingsPage() {
                   <button
                     onClick={handleSaveSettings}
                     disabled={saving || !settingsChanged}
-                    className={`flex items-center gap-2 py-2.5 px-5 rounded-xl font-semibold text-sm transition-all ${
-                      saving || !settingsChanged
-                        ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
-                        : 'bg-amber-500 hover:bg-amber-600 text-white'
-                    }`}
+                    className="btn-primary px-5 py-2.5 text-sm"
                   >
                     {saving ? (
                       <>

--- a/client/src/components/StorefrontPage.tsx
+++ b/client/src/components/StorefrontPage.tsx
@@ -107,10 +107,7 @@ export function StorefrontPage() {
           <p className="text-slate-400 mb-8">
             This seller doesn't exist on Stashu or the link is invalid.
           </p>
-          <Link
-            to="/"
-            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <Link to="/" className="btn-primary px-6 py-3">
             Go Home
           </Link>
         </div>
@@ -128,10 +125,7 @@ export function StorefrontPage() {
           </div>
           <h1 className="text-2xl font-bold text-white mb-4">Storefront Not Available</h1>
           <p className="text-slate-400 mb-8">This seller hasn't enabled their public storefront.</p>
-          <Link
-            to="/"
-            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <Link to="/" className="btn-primary px-6 py-3">
             Go Home
           </Link>
         </div>
@@ -149,10 +143,7 @@ export function StorefrontPage() {
           </div>
           <h1 className="text-2xl font-bold text-white mb-4">Failed to Load Storefront</h1>
           <p className="text-slate-400 mb-8">{error}</p>
-          <button
-            onClick={() => window.location.reload()}
-            className="py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <button onClick={() => window.location.reload()} className="btn-primary px-6 py-3">
             Try Again
           </button>
         </div>

--- a/client/src/components/Toast.tsx
+++ b/client/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
+import { Check, Info, X } from 'lucide-react';
 import { ToastContext } from './useToast';
 
 interface Toast {
@@ -35,58 +36,41 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 }
 
 function ToastItem({ toast }: { toast: Toast }) {
-  const bgColors = {
-    success: 'bg-emerald-600',
-    error: 'bg-rose-600',
-    info: 'bg-slate-700',
+  const styles = {
+    success: {
+      shell:
+        'border-emerald-400/25 bg-emerald-500/10 text-emerald-50 shadow-[0_18px_60px_rgba(16,185,129,0.16)]',
+      icon: 'border-emerald-300/25 bg-emerald-400/10 text-emerald-300',
+      Icon: Check,
+    },
+    error: {
+      shell:
+        'border-rose-400/25 bg-rose-500/10 text-rose-50 shadow-[0_18px_60px_rgba(244,63,94,0.16)]',
+      icon: 'border-rose-300/25 bg-rose-400/10 text-rose-300',
+      Icon: X,
+    },
+    info: {
+      shell:
+        'border-slate-500/30 bg-slate-800/80 text-slate-100 shadow-[0_18px_60px_rgba(15,23,42,0.32)]',
+      icon: 'border-slate-400/20 bg-slate-400/10 text-slate-300',
+      Icon: Info,
+    },
   };
-
-  const icons = {
-    success: (
-      <svg
-        className="w-5 h-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2.5}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-      </svg>
-    ),
-    error: (
-      <svg
-        className="w-5 h-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2.5}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-      </svg>
-    ),
-    info: (
-      <svg
-        className="w-5 h-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2.5}
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-      </svg>
-    ),
-  };
+  const { Icon } = styles[toast.type];
 
   return (
-    <div className="fixed top-6 right-6 z-50 pointer-events-none">
+    <div className="fixed top-5 right-4 left-4 sm:left-auto sm:right-5 z-50 pointer-events-none">
       <div
-        className={`${bgColors[toast.type]} ${toast.exiting ? 'toast-exit' : 'toast-enter'}
-                    text-white px-5 py-3.5 rounded-2xl shadow-2xl
-                    flex items-center gap-3 min-w-70 max-w-sm
-                    pointer-events-auto border border-white/10`}
+        className={`${styles[toast.type].shell} ${toast.exiting ? 'toast-exit' : 'toast-enter'}
+                    pointer-events-auto ml-auto flex w-full max-w-sm items-center gap-3
+                    rounded-xl border px-4 py-3 backdrop-blur-xl`}
       >
-        <span className="text-white/90">{icons[toast.type]}</span>
-        <p className="flex-1 text-sm font-semibold tracking-wide">{toast.message}</p>
+        <span
+          className={`${styles[toast.type].icon} flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border`}
+        >
+          <Icon className="h-4 w-4" strokeWidth={2.5} />
+        </span>
+        <p className="flex-1 text-sm font-semibold leading-snug">{toast.message}</p>
       </div>
     </div>
   );

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -335,10 +335,7 @@ export function UnlockPage() {
           <p className="text-slate-400 mb-8">
             {unlock.error || 'This stash may have been removed or the link is invalid.'}
           </p>
-          <Link
-            to="/"
-            className="inline-block py-3 px-6 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition-colors"
-          >
+          <Link to="/" className="btn-primary px-6 py-3">
             Go Home
           </Link>
         </div>
@@ -432,7 +429,7 @@ export function UnlockPage() {
 
           <button
             onClick={() => unlock.download()}
-            className="w-full py-4 px-6 bg-green-500 hover:bg-green-600 text-white font-bold text-lg rounded-xl transition-colors mb-4 flex items-center justify-center gap-2"
+            className="btn-success mb-4 w-full px-6 py-4 text-lg"
           >
             <Download className="w-5 h-5" />
             Download File
@@ -619,10 +616,7 @@ export function UnlockPage() {
                     {timeLeft !== null && timeLeft <= 0 && (
                       <div className="text-center mb-4">
                         <p className="text-rose-400 text-sm mb-2">Invoice expired</p>
-                        <button
-                          onClick={refreshInvoice}
-                          className="inline-flex items-center gap-2 py-2 px-4 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-sm font-semibold transition-colors"
-                        >
+                        <button onClick={refreshInvoice} className="btn-primary px-4 py-2 text-sm">
                           <RefreshCw className="w-4 h-4" />
                           New Invoice
                         </button>
@@ -721,9 +715,7 @@ export function UnlockPage() {
                   disabled={
                     !token.trim() || unlock.status === 'unlocking' || unlock.status === 'decrypting'
                   }
-                  className="w-full py-4 px-6 bg-orange-500 hover:bg-orange-600
-                       text-white font-bold text-lg rounded-xl transition-colors
-                       disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="btn-primary w-full px-6 py-4 text-lg"
                 >
                   {unlock.status === 'unlocking' || unlock.status === 'decrypting'
                     ? 'Processing...'

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { QRCodeSVG } from 'qrcode.react';
 import {
@@ -14,9 +14,14 @@ import {
   LockOpen,
   Package,
   Download,
+  FileText,
+  ShieldAlert,
+  ShieldCheck,
 } from 'lucide-react';
 import { useUnlock } from '../lib/useUnlock';
 import { createPayInvoice, checkPayStatus } from '../lib/api';
+import { verifyGeneratedPreviewBundle } from '../lib/verifiedPreview';
+import type { StashProofSecret, TextPreviewMetadata } from '../../../shared/types';
 
 type PayTab = 'lightning' | 'cashu';
 
@@ -31,9 +36,33 @@ export function UnlockPage() {
   const [lnLoading, setLnLoading] = useState(false);
   const [lnError, setLnError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [showVerificationDetails, setShowVerificationDetails] = useState(false);
+  const [proofRootCopied, setProofRootCopied] = useState(false);
   const [timeLeft, setTimeLeft] = useState<number | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const previewVerification = useMemo(
+    () => verifyGeneratedPreviewBundle(unlock.stash?.generatedPreview, unlock.stash?.previewProof),
+    [unlock.stash?.generatedPreview, unlock.stash?.previewProof]
+  );
+  const previewStats = useMemo(() => {
+    if (!unlock.stash?.generatedPreview || unlock.stash.generatedPreview.kind !== 'text-peek') {
+      return null;
+    }
+
+    const metadata = unlock.stash.generatedPreview.metadata as TextPreviewMetadata;
+    const percent =
+      unlock.stash.generatedPreview.fileSize > 0
+        ? Math.round((metadata.previewBytes / unlock.stash.generatedPreview.fileSize) * 1000) / 10
+        : 0;
+
+    return {
+      bytes: metadata.previewBytes,
+      lines: metadata.linesIncluded,
+      percent,
+    };
+  }, [unlock.stash?.generatedPreview]);
+  const previewProofInvalid = previewVerification.state === 'invalid';
 
   useEffect(() => {
     if (id) {
@@ -70,6 +99,7 @@ export function UnlockPage() {
       blobSha256?: string;
       fileName?: string;
       claimToken?: string;
+      previewSecret?: StashProofSecret;
     }) => {
       unlock.submitLightningResult(data);
     },
@@ -123,6 +153,7 @@ export function UnlockPage() {
               blobSha256: status.blobSha256,
               fileName: status.fileName,
               claimToken: status.claimToken,
+              previewSecret: status.previewSecret,
             });
           }
         } catch (err) {
@@ -143,6 +174,10 @@ export function UnlockPage() {
 
   const createInvoice = useCallback(async () => {
     if (!id) return;
+    if (previewProofInvalid) {
+      setLnError('Preview verification failed. Payment is disabled for this stash.');
+      return;
+    }
     setLnLoading(true);
     setLnError(null);
 
@@ -154,7 +189,7 @@ export function UnlockPage() {
     } finally {
       setLnLoading(false);
     }
-  }, [id, startTimerAndPolling]);
+  }, [id, previewProofInvalid, startTimerAndPolling]);
 
   // Auto-create or resume invoice when Lightning tab is active and stash is loaded
   useEffect(() => {
@@ -164,7 +199,8 @@ export function UnlockPage() {
       invoice ||
       lnLoading ||
       unlock.status !== 'ready' ||
-      !claimAttempted.current
+      !claimAttempted.current ||
+      previewProofInvalid
     ) {
       return;
     }
@@ -200,6 +236,7 @@ export function UnlockPage() {
     id,
     createInvoice,
     startTimerAndPolling,
+    previewProofInvalid,
   ]);
 
   const refreshInvoice = () => {
@@ -234,6 +271,21 @@ export function UnlockPage() {
       // fallback
     }
   };
+
+  const copyProofRoot = async () => {
+    const proofRoot = unlock.stash?.previewProof?.root;
+    if (!proofRoot) return;
+
+    try {
+      await navigator.clipboard.writeText(proofRoot);
+      setProofRootCopied(true);
+      setTimeout(() => setProofRootCopied(false), 2000);
+    } catch {
+      // fallback
+    }
+  };
+
+  const shortHash = (hash: string): string => `${hash.slice(0, 12)}...${hash.slice(-12)}`;
 
   const formatFileSize = (bytes: number): string => {
     if (bytes < 1024) return `${bytes} B`;
@@ -305,6 +357,79 @@ export function UnlockPage() {
           <h1 className="text-3xl font-bold text-white mb-4">Unlocked!</h1>
           <p className="text-slate-400 mb-8">Your file is ready to download.</p>
 
+          {unlock.stash?.previewProof && (
+            <div className="mb-6 rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-left">
+              <div className="mb-2 flex items-center gap-2">
+                <ShieldCheck className="h-5 w-5 text-emerald-400" />
+                <p className="font-semibold text-emerald-300">Download verified</p>
+              </div>
+              <p className="text-sm text-emerald-50/70">
+                The decrypted file matched the same commitment checked before payment.
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowVerificationDetails((value) => !value)}
+                className="mt-3 text-sm font-medium text-emerald-300 transition-colors hover:text-emerald-100"
+              >
+                {showVerificationDetails ? 'Hide verification details' : 'Verification details'}
+              </button>
+
+              {showVerificationDetails && (
+                <div className="soft-appear mt-4 space-y-3 rounded-lg border border-emerald-500/20 bg-slate-950/40 p-3">
+                  <div className="grid gap-3 text-sm sm:grid-cols-2">
+                    <div>
+                      <p className="text-xs text-slate-500">Preview proof</p>
+                      <p className="font-medium text-emerald-200">Verified</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-slate-500">Unlocked file</p>
+                      <p className="font-medium text-emerald-200">Matched</p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-slate-500">File size</p>
+                      <p className="font-medium text-slate-200">
+                        {formatFileSize(unlock.stash.fileSize)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs text-slate-500">Public peek</p>
+                      <p className="font-medium text-slate-200">
+                        {previewStats
+                          ? `${previewStats.lines} line${previewStats.lines === 1 ? '' : 's'} / ${previewStats.percent}%`
+                          : 'None'}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg bg-slate-950/60 p-3">
+                    <p className="mb-1 text-xs text-slate-500">Proof root</p>
+                    <div className="flex items-center justify-between gap-3">
+                      <code className="truncate font-mono text-xs text-slate-300">
+                        {shortHash(unlock.stash.previewProof.root)}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={copyProofRoot}
+                        className="shrink-0 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 transition-colors hover:border-emerald-500/50 hover:text-emerald-200"
+                      >
+                        {proofRootCopied ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                  </div>
+
+                  {unlock.blobSha256 && (
+                    <div className="rounded-lg bg-slate-950/60 p-3">
+                      <p className="mb-1 text-xs text-slate-500">Blob SHA-256</p>
+                      <code className="block truncate font-mono text-xs text-slate-300">
+                        {shortHash(unlock.blobSha256)}
+                      </code>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
           <button
             onClick={() => unlock.download()}
             className="w-full py-4 px-6 bg-green-500 hover:bg-green-600 text-white font-bold text-lg rounded-xl transition-colors mb-4 flex items-center justify-center gap-2"
@@ -355,199 +480,262 @@ export function UnlockPage() {
               <p className="text-orange-400 font-bold text-xl">{unlock.stash?.priceSats} sats</p>
             </div>
           </div>
-        </div>
 
-        {/* Payment Tabs */}
-        <div className="flex mb-6 bg-slate-800/50 rounded-xl p-1">
-          <button
-            onClick={() => setTab('lightning')}
-            className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
-              tab === 'lightning'
-                ? 'bg-amber-500 text-white shadow-lg'
-                : 'text-slate-400 hover:text-white'
-            }`}
-          >
-            <Zap className="w-4 h-4" />
-            Pay with Lightning
-          </button>
-          <button
-            onClick={() => setTab('cashu')}
-            className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
-              tab === 'cashu'
-                ? 'bg-orange-500 text-white shadow-lg'
-                : 'text-slate-400 hover:text-white'
-            }`}
-          >
-            <Key className="w-4 h-4" />
-            Pay with Cashu
-          </button>
-        </div>
-
-        {/* Lightning Tab */}
-        {tab === 'lightning' && (
-          <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6">
-            {lnLoading && !invoice && (
-              <div className="text-center py-8">
-                <Loader2 className="w-8 h-8 text-amber-400 animate-spin mx-auto mb-3" />
-                <p className="text-slate-400 text-sm">Creating Lightning invoice...</p>
+          {unlock.stash?.generatedPreview && (
+            <div
+              className={`mt-5 rounded-xl border p-4 ${
+                previewVerification.state === 'invalid'
+                  ? 'border-rose-500/40 bg-rose-500/10'
+                  : 'border-emerald-500/30 bg-emerald-500/10'
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-3">
+                {previewVerification.state === 'invalid' ? (
+                  <ShieldAlert className="w-4 h-4 text-rose-400" />
+                ) : (
+                  <ShieldCheck className="w-4 h-4 text-emerald-400" />
+                )}
+                <p
+                  className={`text-sm font-semibold ${
+                    previewVerification.state === 'invalid' ? 'text-rose-300' : 'text-emerald-300'
+                  }`}
+                >
+                  {previewVerification.state === 'invalid'
+                    ? 'Stash verification failed'
+                    : 'Verified Peek'}
+                </p>
               </div>
-            )}
 
-            {lnError && (
-              <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4 mb-4">
-                <p className="text-rose-400 text-sm">{lnError}</p>
-                <button onClick={createInvoice} className="mt-2 text-sm text-amber-400 underline">
-                  Try again
-                </button>
-              </div>
-            )}
-
-            {invoice && (
-              <>
-                {/* QR Code */}
-                <div className="flex justify-center mb-4">
-                  <a
-                    href={`lightning:${invoice}`}
-                    className="bg-white p-4 rounded-2xl block hover:shadow-lg hover:shadow-amber-500/20 transition-shadow"
-                  >
-                    <QRCodeSVG
-                      value={invoice.toUpperCase()}
-                      size={240}
-                      level="M"
-                      includeMargin={false}
-                    />
-                  </a>
-                </div>
-
-                {/* Expiry countdown */}
-                {timeLeft !== null && timeLeft > 0 && (
-                  <p className="text-center text-slate-500 text-xs mb-3">
-                    Expires in{' '}
-                    <span className={timeLeft < 60 ? 'text-rose-400 font-bold' : 'text-slate-400'}>
-                      {formatCountdown(timeLeft)}
-                    </span>
+              {previewVerification.state === 'invalid' ? (
+                <p className="rounded-lg bg-rose-950/40 p-3 text-left text-sm text-rose-100/80">
+                  Stashu could not verify the published proof for this stash, so payment is blocked.
+                  Ask the seller for a fresh stash link.
+                </p>
+              ) : previewVerification.text !== undefined ? (
+                <>
+                  <pre className="max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-950/70 p-3 text-left text-sm text-slate-200">
+                    {previewVerification.text || 'Empty preview'}
+                  </pre>
+                  {previewStats && (
+                    <p className="mt-3 text-left text-xs text-slate-500">
+                      {previewStats.bytes.toLocaleString()} bytes · {previewStats.percent}% ·{' '}
+                      {previewStats.lines} line{previewStats.lines === 1 ? '' : 's'}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <div className="flex items-start gap-2 rounded-lg bg-slate-950/50 p-3 text-left">
+                  <FileText className="mt-0.5 w-4 h-4 shrink-0 text-slate-400" />
+                  <p className="text-sm text-slate-400">
+                    No public peek. Stashu will still check the unlocked file against this
+                    commitment after payment.
                   </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {!previewProofInvalid && (
+          <>
+            {/* Payment Tabs */}
+            <div className="flex mb-6 bg-slate-800/50 rounded-xl p-1">
+              <button
+                onClick={() => setTab('lightning')}
+                className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
+                  tab === 'lightning'
+                    ? 'bg-amber-500 text-white shadow-lg'
+                    : 'text-slate-400 hover:text-white'
+                }`}
+              >
+                <Zap className="w-4 h-4" />
+                Pay with Lightning
+              </button>
+              <button
+                onClick={() => setTab('cashu')}
+                className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
+                  tab === 'cashu'
+                    ? 'bg-orange-500 text-white shadow-lg'
+                    : 'text-slate-400 hover:text-white'
+                }`}
+              >
+                <Key className="w-4 h-4" />
+                Pay with Cashu
+              </button>
+            </div>
+
+            {/* Lightning Tab */}
+            {tab === 'lightning' && (
+              <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-6">
+                {lnLoading && !invoice && (
+                  <div className="text-center py-8">
+                    <Loader2 className="w-8 h-8 text-amber-400 animate-spin mx-auto mb-3" />
+                    <p className="text-slate-400 text-sm">Creating Lightning invoice...</p>
+                  </div>
                 )}
 
-                {/* Expired state */}
-                {timeLeft !== null && timeLeft <= 0 && (
-                  <div className="text-center mb-4">
-                    <p className="text-rose-400 text-sm mb-2">Invoice expired</p>
+                {lnError && (
+                  <div className="bg-rose-500/10 border border-rose-500/30 rounded-xl p-4 mb-4">
+                    <p className="text-rose-400 text-sm">{lnError}</p>
                     <button
-                      onClick={refreshInvoice}
-                      className="inline-flex items-center gap-2 py-2 px-4 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-sm font-semibold transition-colors"
+                      onClick={createInvoice}
+                      className="mt-2 text-sm text-amber-400 underline"
                     >
-                      <RefreshCw className="w-4 h-4" />
-                      New Invoice
+                      Try again
                     </button>
                   </div>
                 )}
 
-                {/* Not expired — show action buttons */}
-                {(timeLeft === null || timeLeft > 0) && (
+                {invoice && (
                   <>
-                    <p className="text-center text-slate-400 text-sm mb-4">
-                      Scan with any Lightning wallet to pay
-                    </p>
-
-                    {/* Open in wallet + Copy buttons */}
-                    <div className="flex gap-2 mb-3">
+                    {/* QR Code */}
+                    <div className="flex justify-center mb-4">
                       <a
                         href={`lightning:${invoice}`}
-                        className="flex-1 flex items-center justify-center gap-2 py-3 bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 rounded-xl transition-colors text-sm text-amber-400 font-medium"
+                        className="bg-white p-4 rounded-2xl block hover:shadow-lg hover:shadow-amber-500/20 transition-shadow"
                       >
-                        <ExternalLink className="w-4 h-4" />
-                        Open in Wallet
+                        <QRCodeSVG
+                          value={invoice.toUpperCase()}
+                          size={240}
+                          level="M"
+                          includeMargin={false}
+                        />
                       </a>
-                      <button
-                        onClick={copyInvoice}
-                        className="flex-1 flex items-center justify-center gap-2 py-3 bg-slate-900 border border-slate-700 hover:border-amber-500/50 rounded-xl transition-colors text-sm"
-                      >
-                        {copied ? (
-                          <>
-                            <Check className="w-4 h-4 text-green-400" />
-                            <span className="text-green-400">Copied!</span>
-                          </>
-                        ) : (
-                          <>
-                            <Copy className="w-4 h-4 text-slate-400" />
-                            <span className="text-slate-400">Copy Invoice</span>
-                          </>
-                        )}
-                      </button>
                     </div>
 
-                    {/* Waiting indicator */}
-                    <div className="flex items-center justify-center gap-2 text-amber-400 text-sm">
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                      Waiting for payment...
-                    </div>
+                    {/* Expiry countdown */}
+                    {timeLeft !== null && timeLeft > 0 && (
+                      <p className="text-center text-slate-500 text-xs mb-3">
+                        Expires in{' '}
+                        <span
+                          className={timeLeft < 60 ? 'text-rose-400 font-bold' : 'text-slate-400'}
+                        >
+                          {formatCountdown(timeLeft)}
+                        </span>
+                      </p>
+                    )}
+
+                    {/* Expired state */}
+                    {timeLeft !== null && timeLeft <= 0 && (
+                      <div className="text-center mb-4">
+                        <p className="text-rose-400 text-sm mb-2">Invoice expired</p>
+                        <button
+                          onClick={refreshInvoice}
+                          className="inline-flex items-center gap-2 py-2 px-4 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-sm font-semibold transition-colors"
+                        >
+                          <RefreshCw className="w-4 h-4" />
+                          New Invoice
+                        </button>
+                      </div>
+                    )}
+
+                    {/* Not expired — show action buttons */}
+                    {(timeLeft === null || timeLeft > 0) && (
+                      <>
+                        <p className="text-center text-slate-400 text-sm mb-4">
+                          Scan with any Lightning wallet to pay
+                        </p>
+
+                        {/* Open in wallet + Copy buttons */}
+                        <div className="flex gap-2 mb-3">
+                          <a
+                            href={`lightning:${invoice}`}
+                            className="flex-1 flex items-center justify-center gap-2 py-3 bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 rounded-xl transition-colors text-sm text-amber-400 font-medium"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                            Open in Wallet
+                          </a>
+                          <button
+                            onClick={copyInvoice}
+                            className="flex-1 flex items-center justify-center gap-2 py-3 bg-slate-900 border border-slate-700 hover:border-amber-500/50 rounded-xl transition-colors text-sm"
+                          >
+                            {copied ? (
+                              <>
+                                <Check className="w-4 h-4 text-green-400" />
+                                <span className="text-green-400">Copied!</span>
+                              </>
+                            ) : (
+                              <>
+                                <Copy className="w-4 h-4 text-slate-400" />
+                                <span className="text-slate-400">Copy Invoice</span>
+                              </>
+                            )}
+                          </button>
+                        </div>
+
+                        {/* Waiting indicator */}
+                        <div className="flex items-center justify-center gap-2 text-amber-400 text-sm">
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Waiting for payment...
+                        </div>
+                      </>
+                    )}
                   </>
                 )}
-              </>
+              </div>
             )}
-          </div>
-        )}
 
-        {/* Cashu Tab */}
-        {tab === 'cashu' && (
-          <>
-            <div className="mb-6">
-              <label className="block text-slate-300 mb-2 font-medium">
-                Paste your Cashu token
-              </label>
-              <textarea
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                placeholder="cashuA..."
-                rows={4}
-                disabled={unlock.status === 'unlocking' || unlock.status === 'decrypting'}
-                className="w-full px-4 py-3 bg-slate-800 border border-slate-600 
+            {/* Cashu Tab */}
+            {tab === 'cashu' && (
+              <>
+                <div className="mb-6">
+                  <label className="block text-slate-300 mb-2 font-medium">
+                    Paste your Cashu token
+                  </label>
+                  <textarea
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder="cashuA..."
+                    rows={4}
+                    disabled={unlock.status === 'unlocking' || unlock.status === 'decrypting'}
+                    className="w-full px-4 py-3 bg-slate-800 border border-slate-600
                          rounded-xl text-white placeholder-slate-500 font-mono text-sm
                          focus:outline-none focus:border-orange-500 resize-none
                          disabled:opacity-50"
-              />
-              <p className="text-slate-500 text-sm mt-2">
-                Get tokens from{' '}
-                <a
-                  href="https://nutstash.app"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-orange-400 underline"
-                >
-                  Nutstash
-                </a>{' '}
-                or{' '}
-                <a
-                  href="https://www.minibits.cash"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-orange-400 underline"
-                >
-                  Minibits
-                </a>
-              </p>
-            </div>
+                  />
+                  <p className="text-slate-500 text-sm mt-2">
+                    Get tokens from{' '}
+                    <a
+                      href="https://nutstash.app"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-orange-400 underline"
+                    >
+                      Nutstash
+                    </a>{' '}
+                    or{' '}
+                    <a
+                      href="https://www.minibits.cash"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-orange-400 underline"
+                    >
+                      Minibits
+                    </a>
+                  </p>
+                </div>
 
-            {/* Unlock Button */}
-            <button
-              onClick={() => unlock.submitToken(token)}
-              disabled={
-                !token.trim() || unlock.status === 'unlocking' || unlock.status === 'decrypting'
-              }
-              className="w-full py-4 px-6 bg-orange-500 hover:bg-orange-600 
+                {/* Unlock Button */}
+                <button
+                  onClick={() => unlock.submitToken(token)}
+                  disabled={
+                    !token.trim() || unlock.status === 'unlocking' || unlock.status === 'decrypting'
+                  }
+                  className="w-full py-4 px-6 bg-orange-500 hover:bg-orange-600
                        text-white font-bold text-lg rounded-xl transition-colors
                        disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {unlock.status === 'unlocking' || unlock.status === 'decrypting'
-                ? 'Processing...'
-                : `Unlock for ${unlock.stash?.priceSats} sats`}
-            </button>
+                >
+                  {unlock.status === 'unlocking' || unlock.status === 'decrypting'
+                    ? 'Processing...'
+                    : `Unlock for ${unlock.stash?.priceSats} sats`}
+                </button>
+              </>
+            )}
           </>
         )}
 
         {/* Error Display (shared) */}
-        {unlock.error && (
+        {unlock.error && !previewProofInvalid && (
           <div className="mt-6 bg-red-500/10 border border-red-500/30 rounded-xl p-4">
             <p className="text-red-400">{unlock.error}</p>
           </div>

--- a/client/src/components/WithdrawModal.tsx
+++ b/client/src/components/WithdrawModal.tsx
@@ -206,11 +206,7 @@ export function WithdrawModal({ totalSats, onClose, onSuccess }: WithdrawModalPr
             <button
               onClick={handleGetQuote}
               disabled={!invoice.trim() || resolving}
-              className={`w-full py-3 rounded-xl font-semibold transition-all ${
-                !invoice.trim() || resolving
-                  ? 'bg-slate-800 text-slate-500 cursor-not-allowed'
-                  : 'bg-amber-500 hover:bg-amber-600 text-white'
-              }`}
+              className="btn-primary w-full py-3"
             >
               {resolving ? (
                 <span className="flex items-center justify-center gap-2">
@@ -270,10 +266,7 @@ export function WithdrawModal({ totalSats, onClose, onSuccess }: WithdrawModalPr
               >
                 Back
               </button>
-              <button
-                onClick={handleWithdraw}
-                className="flex-1 py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-bold transition-colors flex items-center justify-center gap-2"
-              >
+              <button onClick={handleWithdraw} className="btn-primary flex-1 py-3">
                 <Zap className="w-4 h-4" />
                 Withdraw
               </button>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -30,6 +30,9 @@
   /* Effects */
   --shadow-glow: 0 0 50px rgba(249, 115, 22, 0.15);
   --glass-blur: 20px;
+  --ease-soft: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-fast: 160ms;
+  --motion-medium: 240ms;
 }
 
 body {
@@ -75,6 +78,39 @@ h4,
 .font-display {
   font-family: var(--font-display);
   letter-spacing: -0.02em;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :where(a, button, input, textarea, select, [role='button']) {
+    transition-duration: var(--motion-fast);
+    transition-timing-function: var(--ease-soft);
+  }
+
+  :where(a, button, [role='button']) {
+    transition-property: color, background-color, border-color, box-shadow, opacity, transform;
+  }
+
+  :where(input, textarea, select) {
+    transition-property: color, background-color, border-color, box-shadow, opacity;
+  }
+
+  .soft-surface {
+    transition:
+      color var(--motion-fast) var(--ease-soft),
+      background-color var(--motion-fast) var(--ease-soft),
+      border-color var(--motion-fast) var(--ease-soft),
+      box-shadow var(--motion-fast) var(--ease-soft),
+      opacity var(--motion-fast) var(--ease-soft),
+      transform var(--motion-fast) var(--ease-soft);
+  }
+
+  .soft-appear {
+    animation: softAppear var(--motion-medium) var(--ease-soft) both;
+  }
+
+  .route-appear {
+    animation: routeAppear var(--motion-medium) var(--ease-soft) both;
+  }
 }
 
 /* Glass Cards */
@@ -333,4 +369,33 @@ body.modal-open {
 
 .animate-scale-in {
   animation: scaleIn 0.5s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+}
+
+@keyframes softAppear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes routeAppear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -140,20 +140,30 @@ h4,
 
 /* Brand Button */
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-accent-primary) 0%, #ea580c 100%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: rgba(249, 115, 22, 0.94);
   color: white;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(253, 186, 116, 0.24);
   padding: 14px 28px;
   border-radius: 14px;
   font-weight: 600;
-  letter-spacing: 0.01em;
   font-size: 1rem;
+  line-height: 1.25;
+  text-align: center;
+  text-decoration: none;
   cursor: pointer;
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease,
+    background 0.2s ease,
+    border-color 0.2s ease,
     opacity 0.2s;
-  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
+  box-shadow:
+    0 8px 18px rgba(249, 115, 22, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
   position: relative;
   overflow: hidden;
   transform: translateZ(0);
@@ -166,18 +176,73 @@ h4,
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(rgba(255, 255, 255, 0.1), transparent);
+  background: linear-gradient(rgba(255, 255, 255, 0.14), transparent);
   opacity: 0;
   transition: opacity 0.2s;
+  pointer-events: none;
 }
 
-.btn-primary:hover {
+.btn-primary:hover:not(:disabled) {
+  background: rgb(249, 115, 22);
   transform: translateY(-1px) translateZ(0);
-  box-shadow: 0 6px 20px rgba(249, 115, 22, 0.4);
+  border-color: rgba(253, 186, 116, 0.36);
+  box-shadow:
+    0 10px 22px rgba(249, 115, 22, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.btn-primary:hover:not(:disabled)::after {
+  opacity: 1;
 }
 
 .btn-primary:active {
   transform: translateY(0) translateZ(0);
+}
+
+.btn-primary:disabled,
+.btn-primary[aria-disabled='true'] {
+  background: rgba(15, 23, 42, 0.45);
+  border-color: rgba(100, 116, 139, 0.42);
+  color: rgba(148, 163, 184, 0.78);
+  cursor: not-allowed;
+  box-shadow: none;
+  opacity: 1;
+  transform: translateZ(0);
+}
+
+.btn-success {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: rgba(16, 185, 129, 0.9);
+  color: white;
+  border: 1px solid rgba(110, 231, 183, 0.24);
+  padding: 14px 28px;
+  border-radius: 14px;
+  font-weight: 600;
+  line-height: 1.25;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease,
+    border-color 0.2s ease;
+  box-shadow:
+    0 8px 18px rgba(16, 185, 129, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transform: translateZ(0);
+}
+
+.btn-success:hover:not(:disabled) {
+  background: rgb(16, 185, 129);
+  border-color: rgba(110, 231, 183, 0.36);
+  transform: translateY(-1px) translateZ(0);
+  box-shadow:
+    0 10px 22px rgba(16, 185, 129, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
 /* Secondary Button */

--- a/client/src/lib/generatedPreview.test.ts
+++ b/client/src/lib/generatedPreview.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GENERATED_PREVIEW_VERSION,
+  generatePreviewFromBytes,
+  generatePreviewFromFile,
+  serializeGeneratedPreviewPayload,
+  type GeneratedPreviewPayload,
+  type TextLineLimit,
+} from './generatedPreview.js';
+import { createStashProof, verifyPreview, verifyUnlockedFile } from './stashProof.js';
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  return atob(padded);
+}
+
+describe('generated preview payloads', () => {
+  it('generates a text preview from a markdown file', async () => {
+    const file = new File(['one\ntwo\nthree'], 'guide.md', { type: 'text/markdown' });
+
+    const preview = await generatePreviewFromFile(file, { lineLimit: 10 });
+
+    expect(preview.version).toBe(GENERATED_PREVIEW_VERSION);
+    expect(preview.kind).toBe('text-head');
+    expect(preview.fileName).toBe('guide.md');
+    expect(preview.fileType).toBe('text/markdown');
+    expect(preview.fileSize).toBe(file.size);
+    expect(preview.contentType).toBe('text/plain; charset=utf-8');
+    expect(decodeBase64Url(preview.bytes)).toBe('one\ntwo\nthree');
+    expect(preview.metadata).toEqual({
+      lineLimit: 10,
+      linesIncluded: 3,
+      bytesRead: file.size,
+      truncated: false,
+    });
+  });
+
+  it('normalizes CRLF line endings and applies the line limit', () => {
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'notes.txt',
+        fileType: 'text/plain',
+        fileSize: 18,
+        content: bytes('a\r\nb\r\nc\r\nd\r\n'),
+      },
+      { lineLimit: 10 as TextLineLimit, maxChars: 3 }
+    );
+
+    expect(preview.kind).toBe('text-head');
+    expect(decodeBase64Url(preview.bytes)).toBe('a\nb');
+    expect(preview.metadata).toMatchObject({
+      lineLimit: 10,
+      linesIncluded: 2,
+      truncated: true,
+    });
+  });
+
+  it('truncates by the configured line limit', () => {
+    const content = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join('\n');
+
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'long.md',
+        fileType: 'text/markdown',
+        fileSize: bytes(content).length,
+        content: bytes(content),
+      },
+      { lineLimit: 10 }
+    );
+
+    expect(decodeBase64Url(preview.bytes)).toBe(
+      Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join('\n')
+    );
+    expect(preview.metadata).toMatchObject({
+      lineLimit: 10,
+      linesIncluded: 10,
+      truncated: true,
+    });
+  });
+
+  it('truncates by the byte limit before decoding text', () => {
+    const content = bytes('abcdef\nghijkl');
+
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'limited.txt',
+        fileType: 'text/plain',
+        fileSize: content.length,
+        content,
+      },
+      { maxBytes: 6 }
+    );
+
+    expect(decodeBase64Url(preview.bytes)).toBe('abcdef');
+    expect(preview.metadata).toMatchObject({
+      bytesRead: 6,
+      truncated: true,
+    });
+  });
+
+  it('treats code and prompt-like extensions as text when MIME type is empty', () => {
+    const preview = generatePreviewFromBytes({
+      fileName: 'prompt.py',
+      fileType: '',
+      fileSize: 23,
+      content: bytes('print("hello stashu")\n'),
+    });
+
+    expect(preview.kind).toBe('text-head');
+    expect(preview.fileType).toBe('application/octet-stream');
+    expect(decodeBase64Url(preview.bytes)).toBe('print("hello stashu")\n');
+  });
+
+  it('treats text extensions case-insensitively on real File objects', async () => {
+    const preview = await generatePreviewFromFile(new File(['# Hello'], 'README.MD'));
+
+    expect(preview.kind).toBe('text-head');
+    expect(preview.fileType).toBe('application/octet-stream');
+    expect(decodeBase64Url(preview.bytes)).toBe('# Hello');
+  });
+
+  it('treats hidden config files as text', () => {
+    const preview = generatePreviewFromBytes({
+      fileName: '.env',
+      fileType: '',
+      fileSize: 15,
+      content: bytes('TOKEN=example\n'),
+    });
+
+    expect(preview.kind).toBe('text-head');
+    expect(decodeBase64Url(preview.bytes)).toBe('TOKEN=example\n');
+  });
+
+  it('treats structured application MIME types as text', () => {
+    const preview = generatePreviewFromBytes({
+      fileName: 'data',
+      fileType: 'application/json; charset=utf-8',
+      fileSize: 13,
+      content: bytes('{"ok":true}\n'),
+    });
+
+    expect(preview.kind).toBe('text-head');
+    expect(decodeBase64Url(preview.bytes)).toBe('{"ok":true}\n');
+  });
+
+  it('handles empty text files deterministically', async () => {
+    const preview = await generatePreviewFromFile(
+      new File([''], 'empty.txt', { type: 'text/plain' })
+    );
+
+    expect(preview.kind).toBe('text-head');
+    expect(preview.bytes).toBe('');
+    expect(preview.metadata).toEqual({
+      lineLimit: 20,
+      linesIncluded: 0,
+      bytesRead: 0,
+      truncated: false,
+    });
+  });
+
+  it('falls back to a file summary for unsupported binary files', async () => {
+    const file = new File([new Uint8Array([0, 1, 2, 3]).buffer], 'archive.bin', {
+      type: 'application/octet-stream',
+    });
+
+    const preview = await generatePreviewFromFile(file);
+
+    expect(preview).toEqual({
+      version: GENERATED_PREVIEW_VERSION,
+      kind: 'file-summary',
+      fileName: 'archive.bin',
+      fileType: 'application/octet-stream',
+      fileSize: 4,
+      contentType: 'application/octet-stream',
+      options: {},
+      metadata: { reason: 'unsupported-type' },
+      bytes: '',
+    });
+  });
+
+  it('falls back to a file summary when text decoding fails', () => {
+    const preview = generatePreviewFromBytes({
+      fileName: 'broken.txt',
+      fileType: 'text/plain',
+      fileSize: 1,
+      content: new Uint8Array([0xff]),
+    });
+
+    expect(preview.kind).toBe('file-summary');
+    expect(preview.metadata).toEqual({ reason: 'decode-failed' });
+  });
+
+  it('does not reject valid UTF-8 when the byte limit cuts a character suffix', () => {
+    const content = bytes('ab🙂');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'emoji.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { maxBytes: content.length - 1 }
+    );
+
+    expect(preview.kind).toBe('text-head');
+    expect(decodeBase64Url(preview.bytes)).toBe('ab');
+    expect(preview.metadata).toMatchObject({
+      bytesRead: 2,
+      truncated: true,
+    });
+  });
+
+  it('handles real File prefix reads that cut a multibyte character', async () => {
+    const content = bytes('ab🙂');
+    const preview = await generatePreviewFromFile(
+      new File([content.slice().buffer as ArrayBuffer], 'emoji.md', { type: 'text/markdown' }),
+      { maxBytes: content.length - 1 }
+    );
+
+    expect(preview.kind).toBe('text-head');
+    expect(decodeBase64Url(preview.bytes)).toBe('ab');
+    expect(preview.metadata).toMatchObject({
+      bytesRead: 2,
+      truncated: true,
+    });
+  });
+
+  it('keeps unknown extensionless files as summaries even if bytes look textual', () => {
+    const preview = generatePreviewFromBytes({
+      fileName: 'payload',
+      fileType: '',
+      fileSize: 11,
+      content: bytes('hello world'),
+    });
+
+    expect(preview.kind).toBe('file-summary');
+    expect(preview.bytes).toBe('');
+  });
+
+  it('matches file and byte generation for the same source', async () => {
+    const file = new File(['alpha\nbeta\ngamma'], 'same.md', { type: 'text/markdown' });
+    const fromFile = await generatePreviewFromFile(file, { lineLimit: 20 });
+    const fromBytes = generatePreviewFromBytes(
+      {
+        fileName: file.name,
+        fileType: file.type,
+        fileSize: file.size,
+        content: bytes('alpha\nbeta\ngamma'),
+      },
+      { lineLimit: 20 }
+    );
+
+    expect(fromFile).toEqual(fromBytes);
+  });
+
+  it('serializes payloads canonically', async () => {
+    const payload = await generatePreviewFromFile(
+      new File(['hello'], 'hello.txt', { type: 'text/plain' })
+    );
+    const reordered = {
+      bytes: payload.bytes,
+      metadata: payload.metadata,
+      options: payload.options,
+      contentType: payload.contentType,
+      fileSize: payload.fileSize,
+      fileType: payload.fileType,
+      fileName: payload.fileName,
+      kind: payload.kind,
+      version: payload.version,
+    } as GeneratedPreviewPayload;
+
+    expect(serializeGeneratedPreviewPayload(payload)).toEqual(
+      serializeGeneratedPreviewPayload(reordered)
+    );
+  });
+
+  it('can be committed with stash proofs and rejects preview/file tampering', async () => {
+    const fileBytes = bytes('one\ntwo\nthree');
+    const payload = await generatePreviewFromFile(
+      new File([fileBytes.slice().buffer as ArrayBuffer], 'proof.md', { type: 'text/markdown' })
+    );
+    const serializedPayload = serializeGeneratedPreviewPayload(payload);
+    const { proof, secret } = createStashProof(serializedPayload, fileBytes);
+    const tamperedPayload = serializeGeneratedPreviewPayload({
+      ...payload,
+      fileName: 'other.md',
+    });
+
+    expect(verifyPreview(serializedPayload, proof)).toBe(true);
+    expect(verifyPreview(tamperedPayload, proof)).toBe(false);
+    expect(verifyUnlockedFile(fileBytes, proof, secret)).toBe(true);
+    expect(verifyUnlockedFile(bytes('different file'), proof, secret)).toBe(false);
+  });
+
+  it('rejects unsupported text line limits', () => {
+    expect(() =>
+      generatePreviewFromBytes(
+        {
+          fileName: 'notes.md',
+          fileType: 'text/markdown',
+          fileSize: 5,
+          content: bytes('hello'),
+        },
+        { lineLimit: 12 as TextLineLimit }
+      )
+    ).toThrow(/lineLimit/);
+  });
+
+  it('rejects invalid byte and character limits', () => {
+    const source = {
+      fileName: 'notes.md',
+      fileType: 'text/markdown',
+      fileSize: 5,
+      content: bytes('hello'),
+    };
+
+    expect(() => generatePreviewFromBytes(source, { maxBytes: 0 })).toThrow(/maxBytes/);
+    expect(() => generatePreviewFromBytes(source, { maxChars: -1 })).toThrow(/maxChars/);
+  });
+});

--- a/client/src/lib/generatedPreview.test.ts
+++ b/client/src/lib/generatedPreview.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
   GENERATED_PREVIEW_VERSION,
+  decodeGeneratedPreviewBytes,
   generatePreviewFromBytes,
   generatePreviewFromFile,
   serializeGeneratedPreviewPayload,
   type GeneratedPreviewPayload,
   type TextLineLimit,
 } from './generatedPreview.js';
-import { createStashProof, verifyPreview, verifyUnlockedFile } from './stashProof.js';
+import {
+  createStashProof,
+  verifyPreview,
+  verifyPreviewInclusion,
+  verifyUnlockedFile,
+} from './stashProof.js';
 
 const encoder = new TextEncoder();
 
@@ -23,26 +29,51 @@ function decodeBase64Url(value: string): string {
 
 describe('generated preview payloads', () => {
   it('generates a text preview from a markdown file', async () => {
-    const file = new File(['one\ntwo\nthree'], 'guide.md', { type: 'text/markdown' });
+    const content = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join('\n');
+    const file = new File([content], 'guide.md', { type: 'text/markdown' });
 
-    const preview = await generatePreviewFromFile(file, { lineLimit: 10 });
+    const preview = await generatePreviewFromFile(file, {
+      mode: 'auto',
+      lineLimit: 10,
+      maxPreviewRatio: 0.5,
+    });
 
     expect(preview.version).toBe(GENERATED_PREVIEW_VERSION);
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
     expect(preview.fileName).toBe('guide.md');
     expect(preview.fileType).toBe('text/markdown');
     expect(preview.fileSize).toBe(file.size);
     expect(preview.contentType).toBe('text/plain; charset=utf-8');
-    expect(decodeBase64Url(preview.bytes)).toBe('one\ntwo\nthree');
-    expect(preview.metadata).toEqual({
+    expect(decodeBase64Url(preview.bytes)).toBe(
+      Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join('\n')
+    );
+    expect(preview.metadata).toMatchObject({
       lineLimit: 10,
-      linesIncluded: 3,
-      bytesRead: file.size,
-      truncated: false,
+      linesIncluded: 10,
+      truncated: true,
     });
   });
 
-  it('normalizes CRLF line endings and applies the line limit', () => {
+  it('uses the standard default when Auto Peek is enabled', async () => {
+    const content = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join('\n');
+    const file = new File([content], 'standard.md', { type: 'text/markdown' });
+
+    const preview = await generatePreviewFromFile(file, { mode: 'auto' });
+
+    expect(preview.kind).toBe('text-peek');
+    expect(preview.options).toMatchObject({
+      mode: 'auto',
+      lineLimit: 10,
+      maxChars: 2_000,
+      maxPreviewRatio: 0.15,
+    });
+    expect(preview.metadata).toMatchObject({
+      linesIncluded: 10,
+      truncated: true,
+    });
+  });
+
+  it('keeps exact source bytes while applying the character limit', () => {
     const preview = generatePreviewFromBytes(
       {
         fileName: 'notes.txt',
@@ -50,20 +81,21 @@ describe('generated preview payloads', () => {
         fileSize: 18,
         content: bytes('a\r\nb\r\nc\r\nd\r\n'),
       },
-      { lineLimit: 10 as TextLineLimit, maxChars: 3 }
+      { mode: 'auto', lineLimit: 10 as TextLineLimit, maxChars: 3, maxPreviewRatio: 0.5 }
     );
 
-    expect(preview.kind).toBe('text-head');
-    expect(decodeBase64Url(preview.bytes)).toBe('a\nb');
+    expect(preview.kind).toBe('text-peek');
+    expect(decodeBase64Url(preview.bytes)).toBe('a\r\n');
     expect(preview.metadata).toMatchObject({
       lineLimit: 10,
       linesIncluded: 2,
+      previewBytes: 3,
       truncated: true,
     });
   });
 
   it('truncates by the configured line limit', () => {
-    const content = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join('\n');
+    const content = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join('\n');
 
     const preview = generatePreviewFromBytes(
       {
@@ -72,7 +104,7 @@ describe('generated preview payloads', () => {
         fileSize: bytes(content).length,
         content: bytes(content),
       },
-      { lineLimit: 10 }
+      { mode: 'auto', lineLimit: 10, maxPreviewRatio: 0.5 }
     );
 
     expect(decodeBase64Url(preview.bytes)).toBe(
@@ -81,6 +113,7 @@ describe('generated preview payloads', () => {
     expect(preview.metadata).toMatchObject({
       lineLimit: 10,
       linesIncluded: 10,
+      previewBytes: bytes(decodeBase64Url(preview.bytes)).length,
       truncated: true,
     });
   });
@@ -95,74 +128,228 @@ describe('generated preview payloads', () => {
         fileSize: content.length,
         content,
       },
-      { maxBytes: 6 }
+      { mode: 'auto', maxBytes: 6, maxPreviewRatio: 0.5 }
     );
 
     expect(decodeBase64Url(preview.bytes)).toBe('abcdef');
     expect(preview.metadata).toMatchObject({
       bytesRead: 6,
+      previewBytes: 6,
+      truncated: true,
+    });
+  });
+
+  it('drops a partial trailing line when the ratio limit cuts text mid-line', () => {
+    const content = bytes('line 1\nline 2\nline 3\nline 4\n');
+
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'limited.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { mode: 'auto', maxPreviewRatio: 0.45 }
+    );
+
+    expect(preview.kind).toBe('text-peek');
+    expect(decodeBase64Url(preview.bytes)).toBe('line 1');
+    expect(preview.metadata).toMatchObject({
+      linesIncluded: 1,
       truncated: true,
     });
   });
 
   it('treats code and prompt-like extensions as text when MIME type is empty', () => {
-    const preview = generatePreviewFromBytes({
-      fileName: 'prompt.py',
-      fileType: '',
-      fileSize: 23,
-      content: bytes('print("hello stashu")\n'),
-    });
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.py',
+        fileType: '',
+        fileSize: 23,
+        content: bytes('print("hello stashu")\n'),
+      },
+      { mode: 'auto', maxChars: 5, maxPreviewRatio: 0.5 }
+    );
 
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
     expect(preview.fileType).toBe('application/octet-stream');
-    expect(decodeBase64Url(preview.bytes)).toBe('print("hello stashu")\n');
+    expect(decodeBase64Url(preview.bytes)).toBe('print');
   });
 
   it('treats text extensions case-insensitively on real File objects', async () => {
-    const preview = await generatePreviewFromFile(new File(['# Hello'], 'README.MD'));
+    const preview = await generatePreviewFromFile(new File(['# Hello'], 'README.MD'), {
+      mode: 'auto',
+      maxChars: 3,
+      maxPreviewRatio: 0.5,
+    });
 
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
     expect(preview.fileType).toBe('application/octet-stream');
-    expect(decodeBase64Url(preview.bytes)).toBe('# Hello');
+    expect(decodeBase64Url(preview.bytes)).toBe('# H');
   });
 
   it('treats hidden config files as text', () => {
-    const preview = generatePreviewFromBytes({
-      fileName: '.env',
-      fileType: '',
-      fileSize: 15,
-      content: bytes('TOKEN=example\n'),
-    });
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: '.env',
+        fileType: '',
+        fileSize: 15,
+        content: bytes('TOKEN=example\n'),
+      },
+      { mode: 'auto', maxChars: 5, maxPreviewRatio: 0.5 }
+    );
 
-    expect(preview.kind).toBe('text-head');
-    expect(decodeBase64Url(preview.bytes)).toBe('TOKEN=example\n');
+    expect(preview.kind).toBe('text-peek');
+    expect(decodeBase64Url(preview.bytes)).toBe('TOKEN');
   });
 
   it('treats structured application MIME types as text', () => {
-    const preview = generatePreviewFromBytes({
-      fileName: 'data',
-      fileType: 'application/json; charset=utf-8',
-      fileSize: 13,
-      content: bytes('{"ok":true}\n'),
-    });
-
-    expect(preview.kind).toBe('text-head');
-    expect(decodeBase64Url(preview.bytes)).toBe('{"ok":true}\n');
-  });
-
-  it('handles empty text files deterministically', async () => {
-    const preview = await generatePreviewFromFile(
-      new File([''], 'empty.txt', { type: 'text/plain' })
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'data',
+        fileType: 'application/json; charset=utf-8',
+        fileSize: 13,
+        content: bytes('{"ok":true}\n'),
+      },
+      { mode: 'auto', maxChars: 5, maxPreviewRatio: 0.5 }
     );
 
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
+    expect(decodeBase64Url(preview.bytes)).toBe('{"ok"');
+  });
+
+  it('treats CSV, YAML, and shell scripts as text-like files', () => {
+    const cases = [
+      { fileName: 'orders.csv', fileType: 'text/csv', content: 'price,sats\n1,100\n' },
+      { fileName: 'config.yaml', fileType: '', content: 'relay:\n  enabled: true\n' },
+      { fileName: 'deploy.sh', fileType: '', content: '#!/bin/sh\necho stashu\n' },
+    ];
+
+    for (const testCase of cases) {
+      const content = bytes(testCase.content);
+      const preview = generatePreviewFromBytes(
+        {
+          fileName: testCase.fileName,
+          fileType: testCase.fileType,
+          fileSize: content.length,
+          content,
+        },
+        { mode: 'auto', maxChars: 5, maxPreviewRatio: 0.5 }
+      );
+
+      expect(preview.kind).toBe('text-peek');
+    }
+  });
+
+  it('defaults to no public peek', async () => {
+    const preview = await generatePreviewFromFile(
+      new File(['secret prompt'], 'prompt.md', { type: 'text/markdown' })
+    );
+
+    expect(preview.kind).toBe('file-summary');
     expect(preview.bytes).toBe('');
-    expect(preview.metadata).toEqual({
-      lineLimit: 20,
-      linesIncluded: 0,
-      bytesRead: 0,
-      truncated: false,
+    expect(preview.metadata).toEqual({ reason: 'preview-disabled' });
+  });
+
+  it('does not expose complete small text files in Auto Peek', async () => {
+    const preview = await generatePreviewFromFile(
+      new File([''], 'empty.txt', { type: 'text/plain' }),
+      { mode: 'auto', maxPreviewRatio: 0.5 }
+    );
+
+    expect(preview.kind).toBe('file-summary');
+    expect(preview.bytes).toBe('');
+    expect(preview.metadata).toEqual({ reason: 'preview-would-reveal-file' });
+  });
+
+  it('generates a verified peek from a seller-picked excerpt', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+    const offset = bytes('intro\n').length;
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      {
+        mode: 'excerpt',
+        maxPreviewRatio: 0.5,
+        excerpt: {
+          offset,
+          text: 'safe excerpt',
+        },
+      }
+    );
+
+    expect(preview.kind).toBe('text-peek');
+    expect(decodeBase64Url(preview.bytes)).toBe('safe excerpt');
+    expect(preview.options).toMatchObject({ mode: 'excerpt', maxPreviewRatio: 0.5 });
+    expect(preview.metadata).toMatchObject({
+      offset,
+      previewBytes: bytes('safe excerpt').length,
+      truncated: true,
     });
+  });
+
+  it('rejects a seller-picked excerpt that does not match the file range', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+
+    expect(() =>
+      generatePreviewFromBytes(
+        {
+          fileName: 'prompt.md',
+          fileType: 'text/markdown',
+          fileSize: content.length,
+          content,
+        },
+        {
+          mode: 'excerpt',
+          maxPreviewRatio: 0.5,
+          excerpt: {
+            offset: 0,
+            text: 'safe excerpt',
+          },
+        }
+      )
+    ).toThrow(/does not match/);
+  });
+
+  it('rejects a seller-picked excerpt above the line limit', () => {
+    const sourceText = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join('\n');
+    const excerptText = Array.from({ length: 11 }, (_, index) => `line ${index + 1}`).join('\n');
+    const content = bytes(sourceText);
+
+    expect(() =>
+      generatePreviewFromBytes(
+        {
+          fileName: 'prompt.md',
+          fileType: 'text/markdown',
+          fileSize: content.length,
+          content,
+        },
+        {
+          mode: 'excerpt',
+          lineLimit: 10,
+          maxPreviewRatio: 0.5,
+          excerpt: {
+            offset: 0,
+            text: excerptText,
+          },
+        }
+      )
+    ).toThrow(/too many lines/);
+  });
+
+  it('creates a file commitment without a public peek when disabled', async () => {
+    const preview = await generatePreviewFromFile(
+      new File(['secret prompt'], 'prompt.md', { type: 'text/markdown' }),
+      { mode: 'none' }
+    );
+
+    expect(preview.kind).toBe('file-summary');
+    expect(preview.bytes).toBe('');
+    expect(preview.metadata).toEqual({ reason: 'preview-disabled' });
   });
 
   it('falls back to a file summary for unsupported binary files', async () => {
@@ -170,7 +357,7 @@ describe('generated preview payloads', () => {
       type: 'application/octet-stream',
     });
 
-    const preview = await generatePreviewFromFile(file);
+    const preview = await generatePreviewFromFile(file, { mode: 'auto' });
 
     expect(preview).toEqual({
       version: GENERATED_PREVIEW_VERSION,
@@ -185,13 +372,37 @@ describe('generated preview payloads', () => {
     });
   });
 
+  it('falls back to file summaries for images, PDFs, archives, and videos', async () => {
+    const cases = [
+      { fileName: 'photo.png', type: 'image/png' },
+      { fileName: 'paper.pdf', type: 'application/pdf' },
+      { fileName: 'bundle.zip', type: 'application/zip' },
+      { fileName: 'clip.mp4', type: 'video/mp4' },
+    ];
+
+    for (const testCase of cases) {
+      const file = new File([new Uint8Array([1, 2, 3, 4]).buffer], testCase.fileName, {
+        type: testCase.type,
+      });
+
+      const preview = await generatePreviewFromFile(file, { mode: 'auto' });
+
+      expect(preview.kind).toBe('file-summary');
+      expect(preview.metadata).toEqual({ reason: 'unsupported-type' });
+      expect(preview.bytes).toBe('');
+    }
+  });
+
   it('falls back to a file summary when text decoding fails', () => {
-    const preview = generatePreviewFromBytes({
-      fileName: 'broken.txt',
-      fileType: 'text/plain',
-      fileSize: 1,
-      content: new Uint8Array([0xff]),
-    });
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'broken.txt',
+        fileType: 'text/plain',
+        fileSize: 10,
+        content: new Uint8Array(10).fill(0xff),
+      },
+      { mode: 'auto', maxPreviewRatio: 0.5 }
+    );
 
     expect(preview.kind).toBe('file-summary');
     expect(preview.metadata).toEqual({ reason: 'decode-failed' });
@@ -206,13 +417,14 @@ describe('generated preview payloads', () => {
         fileSize: content.length,
         content,
       },
-      { maxBytes: content.length - 1 }
+      { mode: 'auto', maxBytes: content.length - 1, maxPreviewRatio: 0.5 }
     );
 
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
     expect(decodeBase64Url(preview.bytes)).toBe('ab');
     expect(preview.metadata).toMatchObject({
       bytesRead: 2,
+      previewBytes: 2,
       truncated: true,
     });
   });
@@ -221,24 +433,28 @@ describe('generated preview payloads', () => {
     const content = bytes('ab🙂');
     const preview = await generatePreviewFromFile(
       new File([content.slice().buffer as ArrayBuffer], 'emoji.md', { type: 'text/markdown' }),
-      { maxBytes: content.length - 1 }
+      { mode: 'auto', maxBytes: content.length - 1, maxPreviewRatio: 0.5 }
     );
 
-    expect(preview.kind).toBe('text-head');
+    expect(preview.kind).toBe('text-peek');
     expect(decodeBase64Url(preview.bytes)).toBe('ab');
     expect(preview.metadata).toMatchObject({
       bytesRead: 2,
+      previewBytes: 2,
       truncated: true,
     });
   });
 
   it('keeps unknown extensionless files as summaries even if bytes look textual', () => {
-    const preview = generatePreviewFromBytes({
-      fileName: 'payload',
-      fileType: '',
-      fileSize: 11,
-      content: bytes('hello world'),
-    });
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'payload',
+        fileType: '',
+        fileSize: 11,
+        content: bytes('hello world'),
+      },
+      { mode: 'auto' }
+    );
 
     expect(preview.kind).toBe('file-summary');
     expect(preview.bytes).toBe('');
@@ -246,7 +462,7 @@ describe('generated preview payloads', () => {
 
   it('matches file and byte generation for the same source', async () => {
     const file = new File(['alpha\nbeta\ngamma'], 'same.md', { type: 'text/markdown' });
-    const fromFile = await generatePreviewFromFile(file, { lineLimit: 20 });
+    const fromFile = await generatePreviewFromFile(file, { mode: 'auto', lineLimit: 20 });
     const fromBytes = generatePreviewFromBytes(
       {
         fileName: file.name,
@@ -254,7 +470,7 @@ describe('generated preview payloads', () => {
         fileSize: file.size,
         content: bytes('alpha\nbeta\ngamma'),
       },
-      { lineLimit: 20 }
+      { mode: 'auto', lineLimit: 20 }
     );
 
     expect(fromFile).toEqual(fromBytes);
@@ -284,16 +500,19 @@ describe('generated preview payloads', () => {
   it('can be committed with stash proofs and rejects preview/file tampering', async () => {
     const fileBytes = bytes('one\ntwo\nthree');
     const payload = await generatePreviewFromFile(
-      new File([fileBytes.slice().buffer as ArrayBuffer], 'proof.md', { type: 'text/markdown' })
+      new File([fileBytes.slice().buffer as ArrayBuffer], 'proof.md', { type: 'text/markdown' }),
+      { mode: 'auto', maxChars: 5, maxPreviewRatio: 0.5 }
     );
     const serializedPayload = serializeGeneratedPreviewPayload(payload);
-    const { proof, secret } = createStashProof(serializedPayload, fileBytes);
+    const previewContent = decodeGeneratedPreviewBytes(payload);
+    const { proof, secret } = createStashProof(serializedPayload, fileBytes, { previewContent });
     const tamperedPayload = serializeGeneratedPreviewPayload({
       ...payload,
       fileName: 'other.md',
     });
 
     expect(verifyPreview(serializedPayload, proof)).toBe(true);
+    expect(verifyPreviewInclusion(previewContent, proof)).toBe(true);
     expect(verifyPreview(tamperedPayload, proof)).toBe(false);
     expect(verifyUnlockedFile(fileBytes, proof, secret)).toBe(true);
     expect(verifyUnlockedFile(bytes('different file'), proof, secret)).toBe(false);

--- a/client/src/lib/generatedPreview.ts
+++ b/client/src/lib/generatedPreview.ts
@@ -1,27 +1,32 @@
 export const GENERATED_PREVIEW_VERSION = 'stashu-generated-preview-v1' as const;
 
-export const TEXT_LINE_LIMITS = [10, 20, 50] as const;
+export const TEXT_LINE_LIMITS = [4, 10, 20, 50] as const;
 
 export type TextLineLimit = (typeof TEXT_LINE_LIMITS)[number];
-export type GeneratedPreviewKind = 'text-head' | 'file-summary';
+export type GeneratedPreviewKind = 'text-peek' | 'file-summary';
+export type TextPeekMode = 'auto' | 'excerpt';
 
 export interface TextPreviewOptions {
+  mode: TextPeekMode;
   lineLimit: TextLineLimit;
   maxBytes: number;
   maxChars: number;
+  maxPreviewRatio: number;
 }
 
 export type FileSummaryOptions = Record<string, never>;
 
 export interface TextPreviewMetadata {
+  offset: number;
   lineLimit: TextLineLimit;
   linesIncluded: number;
   bytesRead: number;
+  previewBytes: number;
   truncated: boolean;
 }
 
 export interface FileSummaryMetadata {
-  reason: 'unsupported-type' | 'decode-failed';
+  reason: 'unsupported-type' | 'decode-failed' | 'preview-disabled' | 'preview-would-reveal-file';
 }
 
 export interface GeneratedPreviewPayload {
@@ -44,15 +49,34 @@ export interface PreviewSource {
 }
 
 export interface GeneratePreviewOptions {
+  mode?: TextPeekMode | 'none';
   lineLimit?: TextLineLimit;
   maxBytes?: number;
   maxChars?: number;
+  maxPreviewRatio?: number;
+  excerpt?: {
+    offset: number;
+    text?: string;
+    bytes?: Uint8Array | ArrayBuffer;
+  };
+}
+
+interface NormalizedGeneratePreviewOptions {
+  mode: TextPeekMode | 'none';
+  lineLimit: TextLineLimit;
+  maxBytes: number;
+  maxChars: number;
+  maxPreviewRatio: number;
+  excerpt?: GeneratePreviewOptions['excerpt'];
 }
 
 const DEFAULT_FILE_TYPE = 'application/octet-stream';
-const DEFAULT_TEXT_LINE_LIMIT: TextLineLimit = 20;
-const DEFAULT_TEXT_MAX_BYTES = 64 * 1024;
-const DEFAULT_TEXT_MAX_CHARS = 8_000;
+export const DEFAULT_TEXT_LINE_LIMIT: TextLineLimit = 10;
+export const DEFAULT_TEXT_MAX_BYTES = 16 * 1024;
+export const DEFAULT_TEXT_MAX_CHARS = 2_000;
+export const MAX_TEXT_PREVIEW_CHARS = 4_000;
+export const DEFAULT_TEXT_PREVIEW_RATIO = 0.15;
+export const MAX_TEXT_PREVIEW_RATIO = 0.5;
 
 const textExtensions = new Set([
   'bash',
@@ -139,9 +163,31 @@ function normalizePositiveInteger(
   return value;
 }
 
+function normalizePreviewRatio(value?: number): number {
+  if (value === undefined) return DEFAULT_TEXT_PREVIEW_RATIO;
+  if (!Number.isFinite(value) || value < 0 || value > MAX_TEXT_PREVIEW_RATIO) {
+    throw new Error(`maxPreviewRatio must be between 0 and ${MAX_TEXT_PREVIEW_RATIO}`);
+  }
+
+  return value;
+}
+
 function bytesToBase64Url(bytes: Uint8Array): string {
   const base64 = btoa(String.fromCharCode(...bytes));
   return base64.replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  const raw = atob(padded);
+  const bytes = new Uint8Array(raw.length);
+
+  for (let i = 0; i < raw.length; i += 1) {
+    bytes[i] = raw.charCodeAt(i);
+  }
+
+  return bytes;
 }
 
 function decodeUtf8Prefix(
@@ -157,6 +203,9 @@ function decodeUtf8Prefix(
     for (let trim = 1; trim <= maxTrim; trim += 1) {
       try {
         const trimmed = bytes.slice(0, bytes.length - trim);
+        if (trimmed.length === 0 && bytes.length > 0) {
+          throw error;
+        }
         return { text: utf8Decoder.decode(trimmed), bytesRead: trimmed.length };
       } catch {
         // Keep trimming only enough bytes to remove a partial UTF-8 suffix.
@@ -165,6 +214,64 @@ function decodeUtf8Prefix(
 
     throw error;
   }
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  return text.split(/\r\n|\r|\n/).length;
+}
+
+function firstLinesPrefix(
+  text: string,
+  lineLimit: TextLineLimit
+): {
+  text: string;
+  truncated: boolean;
+} {
+  let linesSeen = 1;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    const isCrLf = char === '\r' && text[i + 1] === '\n';
+
+    if (char === '\n' || char === '\r') {
+      if (linesSeen >= lineLimit) {
+        return {
+          text: text.slice(0, i),
+          truncated: i < text.length,
+        };
+      }
+
+      linesSeen += 1;
+      if (isCrLf) i += 1;
+    }
+  }
+
+  return { text, truncated: false };
+}
+
+function sliceByCodePoints(text: string, maxChars: number): { text: string; truncated: boolean } {
+  const chars = Array.from(text);
+  if (chars.length <= maxChars) return { text, truncated: false };
+
+  return {
+    text: chars.slice(0, maxChars).join(''),
+    truncated: true,
+  };
+}
+
+function trimTrailingPartialLine(text: string): { text: string; truncated: boolean } {
+  if (text.length === 0 || text.endsWith('\n') || text.endsWith('\r')) {
+    return { text, truncated: false };
+  }
+
+  const lineBreak = Math.max(text.lastIndexOf('\n'), text.lastIndexOf('\r'));
+  if (lineBreak === -1) return { text, truncated: false };
+
+  return {
+    text: text.slice(0, lineBreak),
+    truncated: true,
+  };
 }
 
 function createFileSummary(
@@ -186,54 +293,147 @@ function createFileSummary(
 
 function createTextPreview(
   source: PreviewSource,
-  options: Required<GeneratePreviewOptions>
+  options: NormalizedGeneratePreviewOptions
 ): GeneratedPreviewPayload {
+  if (options.mode === 'none' || options.maxPreviewRatio === 0) {
+    return createFileSummary(source, 'preview-disabled');
+  }
+
   const content = toBytes(source.content);
-  const requestedBytes = Math.min(content.length, options.maxBytes);
+  const ratioLimit = Math.floor(source.fileSize * options.maxPreviewRatio);
+  if (ratioLimit < 1) {
+    return createFileSummary(source, 'preview-would-reveal-file');
+  }
+
+  const requestedBytes = Math.min(content.length, options.maxBytes, ratioLimit);
   const previewBytes = content.slice(0, requestedBytes);
   const { text, bytesRead } = decodeUtf8Prefix(previewBytes, source.fileSize > requestedBytes);
-  const decoded = text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
-  const lines = decoded.split('\n');
-  const includedLines = lines.slice(0, options.lineLimit);
+  const readWasCut = source.fileSize > bytesRead;
+  const lineLimited = firstLinesPrefix(text, options.lineLimit);
+  const completeLineLimited =
+    readWasCut && !lineLimited.truncated
+      ? trimTrailingPartialLine(lineLimited.text)
+      : { text: lineLimited.text, truncated: false };
+  const charLimited = sliceByCodePoints(completeLineLimited.text, options.maxChars);
+  const exactPreviewBytes = encoder.encode(charLimited.text);
+  const truncated =
+    readWasCut || lineLimited.truncated || completeLineLimited.truncated || charLimited.truncated;
 
-  let previewText = includedLines.join('\n');
-  let truncated =
-    source.fileSize > bytesRead ||
-    lines.length > options.lineLimit ||
-    decoded.length > previewText.length;
-
-  if (previewText.length > options.maxChars) {
-    previewText = previewText.slice(0, options.maxChars);
-    truncated = true;
+  if (!truncated || exactPreviewBytes.length === 0) {
+    return createFileSummary(source, 'preview-would-reveal-file');
   }
 
   return {
     version: GENERATED_PREVIEW_VERSION,
-    kind: 'text-head',
+    kind: 'text-peek',
     fileName: source.fileName,
     fileType: normalizeFileType(source.fileType),
     fileSize: source.fileSize,
     contentType: 'text/plain; charset=utf-8',
     options: {
+      mode: 'auto',
       lineLimit: options.lineLimit,
       maxBytes: options.maxBytes,
       maxChars: options.maxChars,
+      maxPreviewRatio: options.maxPreviewRatio,
     },
     metadata: {
+      offset: 0,
       lineLimit: options.lineLimit,
-      linesIncluded: previewText.length === 0 ? 0 : previewText.split('\n').length,
+      linesIncluded: countLines(charLimited.text),
       bytesRead,
+      previewBytes: exactPreviewBytes.length,
       truncated,
     },
-    bytes: bytesToBase64Url(encoder.encode(previewText)),
+    bytes: bytesToBase64Url(exactPreviewBytes),
   };
 }
 
-function normalizeOptions(options: GeneratePreviewOptions): Required<GeneratePreviewOptions> {
+function createExcerptPreview(
+  source: PreviewSource,
+  options: NormalizedGeneratePreviewOptions
+): GeneratedPreviewPayload {
+  if (!options.excerpt) {
+    throw new Error('Choose text or switch to Auto preview');
+  }
+
+  const content = toBytes(source.content);
+  const excerptBytes = options.excerpt.bytes
+    ? toBytes(options.excerpt.bytes)
+    : encoder.encode(options.excerpt.text ?? '');
+
+  if (
+    !Number.isSafeInteger(options.excerpt.offset) ||
+    options.excerpt.offset < 0 ||
+    excerptBytes.length === 0 ||
+    options.excerpt.offset + excerptBytes.length > source.fileSize
+  ) {
+    throw new Error('Peek excerpt is outside the file');
+  }
+
+  const ratioLimit = Math.floor(source.fileSize * options.maxPreviewRatio);
+  if (
+    excerptBytes.length > ratioLimit ||
+    excerptBytes.length > options.maxBytes ||
+    excerptBytes.length >= source.fileSize
+  ) {
+    throw new Error('Peek excerpt reveals too much of the file');
+  }
+
+  const fileBytesAtOffset = content.slice(
+    options.excerpt.offset,
+    options.excerpt.offset + excerptBytes.length
+  );
+  if (
+    fileBytesAtOffset.length !== excerptBytes.length ||
+    fileBytesAtOffset.some((value, index) => value !== excerptBytes[index])
+  ) {
+    throw new Error('Peek excerpt does not match the file bytes');
+  }
+
+  const text = decodeUtf8Prefix(excerptBytes, false).text;
+  if (countLines(text) > options.lineLimit) {
+    throw new Error('Peek excerpt has too many lines');
+  }
+
+  if (Array.from(text).length > options.maxChars) {
+    throw new Error('Peek excerpt is too long');
+  }
+
   return {
+    version: GENERATED_PREVIEW_VERSION,
+    kind: 'text-peek',
+    fileName: source.fileName,
+    fileType: normalizeFileType(source.fileType),
+    fileSize: source.fileSize,
+    contentType: 'text/plain; charset=utf-8',
+    options: {
+      mode: 'excerpt',
+      lineLimit: options.lineLimit,
+      maxBytes: options.maxBytes,
+      maxChars: options.maxChars,
+      maxPreviewRatio: options.maxPreviewRatio,
+    },
+    metadata: {
+      offset: options.excerpt.offset,
+      lineLimit: options.lineLimit,
+      linesIncluded: countLines(text),
+      bytesRead: excerptBytes.length,
+      previewBytes: excerptBytes.length,
+      truncated: true,
+    },
+    bytes: bytesToBase64Url(excerptBytes),
+  };
+}
+
+function normalizeOptions(options: GeneratePreviewOptions): NormalizedGeneratePreviewOptions {
+  return {
+    mode: options.mode ?? 'none',
     lineLimit: normalizeLineLimit(options.lineLimit),
     maxBytes: normalizePositiveInteger(options.maxBytes, DEFAULT_TEXT_MAX_BYTES, 'maxBytes'),
     maxChars: normalizePositiveInteger(options.maxChars, DEFAULT_TEXT_MAX_CHARS, 'maxChars'),
+    maxPreviewRatio: normalizePreviewRatio(options.maxPreviewRatio),
+    excerpt: options.excerpt,
   };
 }
 
@@ -253,23 +453,42 @@ export function serializeGeneratedPreviewPayload(payload: GeneratedPreviewPayloa
   return encoder.encode(stableStringify(payload));
 }
 
+export function decodeGeneratedPreviewBytes(payload: GeneratedPreviewPayload): Uint8Array {
+  return base64UrlToBytes(payload.bytes);
+}
+
 export function generatePreviewFromBytes(
   source: PreviewSource,
   options: GeneratePreviewOptions = {}
 ): GeneratedPreviewPayload {
   const fileType = normalizeFileType(source.fileType);
+  const normalizedOptions = normalizeOptions(options);
+
+  if (normalizedOptions.mode === 'none' || normalizedOptions.maxPreviewRatio === 0) {
+    return createFileSummary({ ...source, fileType }, 'preview-disabled');
+  }
 
   if (!isTextLike(source.fileName, fileType)) {
     return createFileSummary(source, 'unsupported-type');
   }
 
   try {
+    if (normalizedOptions.mode === 'excerpt') {
+      return createExcerptPreview(
+        {
+          ...source,
+          fileType,
+        },
+        normalizedOptions
+      );
+    }
+
     return createTextPreview(
       {
         ...source,
         fileType,
       },
-      normalizeOptions(options)
+      normalizedOptions
     );
   } catch (error) {
     if (error instanceof TypeError) {
@@ -284,6 +503,19 @@ export async function generatePreviewFromFile(
   options: GeneratePreviewOptions = {}
 ): Promise<GeneratedPreviewPayload> {
   const fileType = normalizeFileType(file.type);
+  const normalizedOptions = normalizeOptions(options);
+
+  if (normalizedOptions.mode === 'none' || normalizedOptions.maxPreviewRatio === 0) {
+    return createFileSummary(
+      {
+        fileName: file.name,
+        fileType,
+        fileSize: file.size,
+      },
+      'preview-disabled'
+    );
+  }
+
   if (!isTextLike(file.name, fileType)) {
     return createFileSummary(
       {
@@ -295,8 +527,10 @@ export async function generatePreviewFromFile(
     );
   }
 
-  const normalizedOptions = normalizeOptions(options);
-  const bytesToRead = Math.min(file.size, normalizedOptions.maxBytes);
+  const bytesToRead =
+    normalizedOptions.mode === 'excerpt'
+      ? file.size
+      : Math.min(file.size, normalizedOptions.maxBytes);
   const content = await file.slice(0, bytesToRead).arrayBuffer();
 
   return generatePreviewFromBytes(

--- a/client/src/lib/generatedPreview.ts
+++ b/client/src/lib/generatedPreview.ts
@@ -1,0 +1,311 @@
+export const GENERATED_PREVIEW_VERSION = 'stashu-generated-preview-v1' as const;
+
+export const TEXT_LINE_LIMITS = [10, 20, 50] as const;
+
+export type TextLineLimit = (typeof TEXT_LINE_LIMITS)[number];
+export type GeneratedPreviewKind = 'text-head' | 'file-summary';
+
+export interface TextPreviewOptions {
+  lineLimit: TextLineLimit;
+  maxBytes: number;
+  maxChars: number;
+}
+
+export type FileSummaryOptions = Record<string, never>;
+
+export interface TextPreviewMetadata {
+  lineLimit: TextLineLimit;
+  linesIncluded: number;
+  bytesRead: number;
+  truncated: boolean;
+}
+
+export interface FileSummaryMetadata {
+  reason: 'unsupported-type' | 'decode-failed';
+}
+
+export interface GeneratedPreviewPayload {
+  version: typeof GENERATED_PREVIEW_VERSION;
+  kind: GeneratedPreviewKind;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  contentType: string;
+  options: TextPreviewOptions | FileSummaryOptions;
+  metadata: TextPreviewMetadata | FileSummaryMetadata;
+  bytes: string;
+}
+
+export interface PreviewSource {
+  fileName: string;
+  fileType?: string;
+  fileSize: number;
+  content: Uint8Array | ArrayBuffer;
+}
+
+export interface GeneratePreviewOptions {
+  lineLimit?: TextLineLimit;
+  maxBytes?: number;
+  maxChars?: number;
+}
+
+const DEFAULT_FILE_TYPE = 'application/octet-stream';
+const DEFAULT_TEXT_LINE_LIMIT: TextLineLimit = 20;
+const DEFAULT_TEXT_MAX_BYTES = 64 * 1024;
+const DEFAULT_TEXT_MAX_CHARS = 8_000;
+
+const textExtensions = new Set([
+  'bash',
+  'conf',
+  'css',
+  'csv',
+  'env',
+  'go',
+  'html',
+  'ini',
+  'js',
+  'json',
+  'jsx',
+  'log',
+  'md',
+  'markdown',
+  'py',
+  'rs',
+  'sh',
+  'toml',
+  'ts',
+  'tsx',
+  'txt',
+  'xml',
+  'yaml',
+  'yml',
+]);
+
+const textMimeTypes = new Set([
+  'application/javascript',
+  'application/json',
+  'application/ld+json',
+  'application/markdown',
+  'application/toml',
+  'application/typescript',
+  'application/x-sh',
+  'application/x-yaml',
+  'application/xml',
+  'application/yaml',
+]);
+
+const encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function normalizeFileType(fileType?: string): string {
+  return fileType?.trim() || DEFAULT_FILE_TYPE;
+}
+
+function fileExtension(fileName: string): string {
+  const lastDot = fileName.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === fileName.length - 1) return '';
+  return fileName.slice(lastDot + 1).toLowerCase();
+}
+
+function isTextLike(fileName: string, fileType: string): boolean {
+  const normalizedType = fileType.toLowerCase().split(';')[0]?.trim() ?? '';
+  return (
+    normalizedType.startsWith('text/') ||
+    textMimeTypes.has(normalizedType) ||
+    textExtensions.has(fileExtension(fileName))
+  );
+}
+
+function normalizeLineLimit(lineLimit?: TextLineLimit): TextLineLimit {
+  if (lineLimit === undefined) return DEFAULT_TEXT_LINE_LIMIT;
+  if (TEXT_LINE_LIMITS.includes(lineLimit)) return lineLimit;
+
+  throw new Error(`lineLimit must be one of ${TEXT_LINE_LIMITS.join(', ')}`);
+}
+
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  name: string
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return base64.replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+function decodeUtf8Prefix(
+  bytes: Uint8Array,
+  canTrimEnd: boolean
+): { text: string; bytesRead: number } {
+  try {
+    return { text: utf8Decoder.decode(bytes), bytesRead: bytes.length };
+  } catch (error) {
+    if (!canTrimEnd) throw error;
+
+    const maxTrim = Math.min(3, bytes.length);
+    for (let trim = 1; trim <= maxTrim; trim += 1) {
+      try {
+        const trimmed = bytes.slice(0, bytes.length - trim);
+        return { text: utf8Decoder.decode(trimmed), bytesRead: trimmed.length };
+      } catch {
+        // Keep trimming only enough bytes to remove a partial UTF-8 suffix.
+      }
+    }
+
+    throw error;
+  }
+}
+
+function createFileSummary(
+  source: Omit<PreviewSource, 'content'>,
+  reason: FileSummaryMetadata['reason']
+): GeneratedPreviewPayload {
+  return {
+    version: GENERATED_PREVIEW_VERSION,
+    kind: 'file-summary',
+    fileName: source.fileName,
+    fileType: normalizeFileType(source.fileType),
+    fileSize: source.fileSize,
+    contentType: 'application/octet-stream',
+    options: {},
+    metadata: { reason },
+    bytes: '',
+  };
+}
+
+function createTextPreview(
+  source: PreviewSource,
+  options: Required<GeneratePreviewOptions>
+): GeneratedPreviewPayload {
+  const content = toBytes(source.content);
+  const requestedBytes = Math.min(content.length, options.maxBytes);
+  const previewBytes = content.slice(0, requestedBytes);
+  const { text, bytesRead } = decodeUtf8Prefix(previewBytes, source.fileSize > requestedBytes);
+  const decoded = text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  const lines = decoded.split('\n');
+  const includedLines = lines.slice(0, options.lineLimit);
+
+  let previewText = includedLines.join('\n');
+  let truncated =
+    source.fileSize > bytesRead ||
+    lines.length > options.lineLimit ||
+    decoded.length > previewText.length;
+
+  if (previewText.length > options.maxChars) {
+    previewText = previewText.slice(0, options.maxChars);
+    truncated = true;
+  }
+
+  return {
+    version: GENERATED_PREVIEW_VERSION,
+    kind: 'text-head',
+    fileName: source.fileName,
+    fileType: normalizeFileType(source.fileType),
+    fileSize: source.fileSize,
+    contentType: 'text/plain; charset=utf-8',
+    options: {
+      lineLimit: options.lineLimit,
+      maxBytes: options.maxBytes,
+      maxChars: options.maxChars,
+    },
+    metadata: {
+      lineLimit: options.lineLimit,
+      linesIncluded: previewText.length === 0 ? 0 : previewText.split('\n').length,
+      bytesRead,
+      truncated,
+    },
+    bytes: bytesToBase64Url(encoder.encode(previewText)),
+  };
+}
+
+function normalizeOptions(options: GeneratePreviewOptions): Required<GeneratePreviewOptions> {
+  return {
+    lineLimit: normalizeLineLimit(options.lineLimit),
+    maxBytes: normalizePositiveInteger(options.maxBytes, DEFAULT_TEXT_MAX_BYTES, 'maxBytes'),
+    maxChars: normalizePositiveInteger(options.maxChars, DEFAULT_TEXT_MAX_CHARS, 'maxChars'),
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+
+  const record = value as Record<string, unknown>;
+  const properties = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+
+  return `{${properties.join(',')}}`;
+}
+
+export function serializeGeneratedPreviewPayload(payload: GeneratedPreviewPayload): Uint8Array {
+  return encoder.encode(stableStringify(payload));
+}
+
+export function generatePreviewFromBytes(
+  source: PreviewSource,
+  options: GeneratePreviewOptions = {}
+): GeneratedPreviewPayload {
+  const fileType = normalizeFileType(source.fileType);
+
+  if (!isTextLike(source.fileName, fileType)) {
+    return createFileSummary(source, 'unsupported-type');
+  }
+
+  try {
+    return createTextPreview(
+      {
+        ...source,
+        fileType,
+      },
+      normalizeOptions(options)
+    );
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return createFileSummary({ ...source, fileType }, 'decode-failed');
+    }
+    throw error;
+  }
+}
+
+export async function generatePreviewFromFile(
+  file: File,
+  options: GeneratePreviewOptions = {}
+): Promise<GeneratedPreviewPayload> {
+  const fileType = normalizeFileType(file.type);
+  if (!isTextLike(file.name, fileType)) {
+    return createFileSummary(
+      {
+        fileName: file.name,
+        fileType,
+        fileSize: file.size,
+      },
+      'unsupported-type'
+    );
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+  const bytesToRead = Math.min(file.size, normalizedOptions.maxBytes);
+  const content = await file.slice(0, bytesToRead).arrayBuffer();
+
+  return generatePreviewFromBytes(
+    {
+      fileName: file.name,
+      fileType,
+      fileSize: file.size,
+      content,
+    },
+    normalizedOptions
+  );
+}

--- a/client/src/lib/stashProof.test.ts
+++ b/client/src/lib/stashProof.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { createStashProof, verifyPreview, verifyUnlockedFile } from './stashProof.js';
+import {
+  createStashProof,
+  verifyPreview,
+  verifyPreviewInclusion,
+  verifyUnlockedFile,
+} from './stashProof.js';
 
 const encoder = new TextEncoder();
 
@@ -10,12 +15,14 @@ function bytes(value: string): Uint8Array {
 describe('stash proof commitments', () => {
   it('keeps the public proof separate from the unlock-only salt', () => {
     const salt = new Uint8Array(32).fill(7);
-    const { proof, secret } = createStashProof(bytes('preview'), bytes('hidden file'), salt);
+    const { proof, secret } = createStashProof(bytes('preview'), bytes('hidden file'), { salt });
 
     expect(proof.version).toBe('stashu-preview-v1');
     expect(proof.root).toMatch(/^[0-9a-f]{64}$/);
     expect(proof.previewHash).toMatch(/^[0-9a-f]{64}$/);
-    expect(proof.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(proof.contentMerkleRoot).toMatch(/^[0-9a-f]{64}$/);
+    expect(proof.contentLength).toBe(11);
+    expect(proof.chunkSize).toBe(64 * 1024);
     expect(Object.keys(proof)).not.toContain('contentSalt');
     expect(secret.contentSalt).toBe('07'.repeat(32));
   });
@@ -24,6 +31,69 @@ describe('stash proof commitments', () => {
     const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
 
     expect(verifyPreview(bytes('public preview'), proof)).toBe(true);
+  });
+
+  it('proves a text peek is part of the committed file', () => {
+    const previewContent = bytes('line 1\nline 2');
+    const hiddenSuffix = bytes('\nline 3\nline 4');
+    const content = new Uint8Array(previewContent.length + hiddenSuffix.length);
+    content.set(previewContent);
+    content.set(hiddenSuffix, previewContent.length);
+    const { proof } = createStashProof(bytes('preview payload'), content, {
+      previewContent,
+      chunkSize: 1024,
+      salt: new Uint8Array(32).fill(1),
+    });
+
+    expect(proof.previewInclusion).toMatchObject({
+      offset: 0,
+      length: previewContent.length,
+    });
+    expect(verifyPreviewInclusion(previewContent, proof)).toBe(true);
+  });
+
+  it('proves a seller-picked excerpt from the middle of the file', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+    const excerpt = bytes('safe excerpt');
+    const offset = bytes('intro\n').length;
+    const { proof, secret } = createStashProof(bytes('preview payload'), content, {
+      previewContent: { offset, bytes: excerpt },
+      chunkSize: 1024,
+      salt: new Uint8Array(32).fill(3),
+    });
+
+    expect(proof.previewInclusion).toMatchObject({
+      offset,
+      length: excerpt.length,
+    });
+    expect(verifyPreviewInclusion(excerpt, proof)).toBe(true);
+    expect(verifyUnlockedFile(content, proof, secret)).toBe(true);
+  });
+
+  it('rejects preview inclusion when the visible bytes are changed', () => {
+    const { proof } = createStashProof(bytes('preview payload'), bytes('preview hidden'), {
+      previewContent: bytes('preview'),
+    });
+
+    expect(verifyPreviewInclusion(bytes('changed'), proof)).toBe(false);
+  });
+
+  it('requires preview content to match the declared file range', () => {
+    expect(() =>
+      createStashProof(bytes('preview payload'), bytes('real file'), {
+        previewContent: bytes('fake'),
+      })
+    ).toThrow(/declared offset/);
+  });
+
+  it('rejects a middle excerpt with the wrong offset', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+
+    expect(() =>
+      createStashProof(bytes('preview payload'), content, {
+        previewContent: { offset: 0, bytes: bytes('safe excerpt') },
+      })
+    ).toThrow(/declared offset/);
   });
 
   it('rejects a tampered preview', () => {
@@ -45,11 +115,9 @@ describe('stash proof commitments', () => {
   });
 
   it('rejects a wrong reveal salt', () => {
-    const { proof } = createStashProof(
-      bytes('public preview'),
-      bytes('hidden file'),
-      new Uint8Array(32).fill(1)
-    );
+    const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'), {
+      salt: new Uint8Array(32).fill(1),
+    });
 
     expect(
       verifyUnlockedFile(bytes('hidden file'), proof, {
@@ -63,7 +131,7 @@ describe('stash proof commitments', () => {
     const second = createStashProof(bytes('same preview'), bytes('same hidden file')).proof;
 
     expect(first.previewHash).toBe(second.previewHash);
-    expect(first.contentHash).not.toBe(second.contentHash);
+    expect(first.contentMerkleRoot).not.toBe(second.contentMerkleRoot);
     expect(first.root).not.toBe(second.root);
   });
 
@@ -73,7 +141,24 @@ describe('stash proof commitments', () => {
     expect(
       verifyPreview(bytes('public preview'), {
         ...proof,
-        contentHash: 'bad',
+        contentMerkleRoot: 'bad',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a tampered Merkle path instead of throwing', () => {
+    const previewContent = bytes('preview');
+    const { proof } = createStashProof(bytes('preview payload'), bytes('preview hidden'), {
+      previewContent,
+    });
+
+    expect(
+      verifyPreviewInclusion(previewContent, {
+        ...proof,
+        previewInclusion: {
+          ...proof.previewInclusion!,
+          path: [{ side: 'right', hash: 'bad' }],
+        },
       })
     ).toBe(false);
   });

--- a/client/src/lib/stashProof.test.ts
+++ b/client/src/lib/stashProof.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { createStashProof, verifyPreview, verifyUnlockedFile } from './stashProof.js';
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+describe('stash proof commitments', () => {
+  it('keeps the public proof separate from the unlock-only salt', () => {
+    const salt = new Uint8Array(32).fill(7);
+    const { proof, secret } = createStashProof(bytes('preview'), bytes('hidden file'), salt);
+
+    expect(proof.version).toBe('stashu-preview-v1');
+    expect(proof.root).toMatch(/^[0-9a-f]{64}$/);
+    expect(proof.previewHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(proof.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(Object.keys(proof)).not.toContain('contentSalt');
+    expect(secret.contentSalt).toBe('07'.repeat(32));
+  });
+
+  it('verifies the preview before payment', () => {
+    const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(verifyPreview(bytes('public preview'), proof)).toBe(true);
+  });
+
+  it('rejects a tampered preview', () => {
+    const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(verifyPreview(bytes('different preview'), proof)).toBe(false);
+  });
+
+  it('verifies the unlocked file with the reveal salt', () => {
+    const { proof, secret } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(verifyUnlockedFile(bytes('hidden file'), proof, secret)).toBe(true);
+  });
+
+  it('rejects a tampered unlocked file', () => {
+    const { proof, secret } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(verifyUnlockedFile(bytes('other file'), proof, secret)).toBe(false);
+  });
+
+  it('rejects a wrong reveal salt', () => {
+    const { proof } = createStashProof(
+      bytes('public preview'),
+      bytes('hidden file'),
+      new Uint8Array(32).fill(1)
+    );
+
+    expect(
+      verifyUnlockedFile(bytes('hidden file'), proof, {
+        contentSalt: '02'.repeat(32),
+      })
+    ).toBe(false);
+  });
+
+  it('uses fresh content salt by default', () => {
+    const first = createStashProof(bytes('same preview'), bytes('same hidden file')).proof;
+    const second = createStashProof(bytes('same preview'), bytes('same hidden file')).proof;
+
+    expect(first.previewHash).toBe(second.previewHash);
+    expect(first.contentHash).not.toBe(second.contentHash);
+    expect(first.root).not.toBe(second.root);
+  });
+
+  it('rejects malformed proof hashes instead of throwing', () => {
+    const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(
+      verifyPreview(bytes('public preview'), {
+        ...proof,
+        contentHash: 'bad',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects missing proof data instead of throwing', () => {
+    expect(verifyPreview(bytes('public preview'), null)).toBe(false);
+    expect(verifyUnlockedFile(bytes('hidden file'), null, null)).toBe(false);
+  });
+
+  it('rejects missing reveal salt instead of throwing', () => {
+    const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
+
+    expect(verifyUnlockedFile(bytes('hidden file'), proof, {})).toBe(false);
+  });
+});

--- a/client/src/lib/stashProof.ts
+++ b/client/src/lib/stashProof.ts
@@ -1,16 +1,32 @@
 import { bytesToHex, sha256 } from './crypto.js';
 
 export const STASH_PROOF_VERSION = 'stashu-preview-v1' as const;
+export const DEFAULT_CONTENT_CHUNK_SIZE = 64 * 1024;
 
 const SALT_LENGTH = 32;
 const MAX_FRAME_LENGTH = 0xffffffff;
 const encoder = new TextEncoder();
 
+export interface MerkleProofStep {
+  side: 'left' | 'right';
+  hash: string;
+}
+
+export interface PreviewInclusionProof {
+  offset: number;
+  length: number;
+  leafHash: string;
+  path: MerkleProofStep[];
+}
+
 export interface StashProof {
   version: typeof STASH_PROOF_VERSION;
   root: string;
   previewHash: string;
-  contentHash: string;
+  contentMerkleRoot: string;
+  contentLength: number;
+  chunkSize: number;
+  previewInclusion?: PreviewInclusionProof;
 }
 
 export interface StashProofSecret {
@@ -20,6 +36,17 @@ export interface StashProofSecret {
 export interface StashProofBundle {
   proof: StashProof;
   secret: StashProofSecret;
+}
+
+export interface CreateStashProofOptions {
+  salt?: Uint8Array;
+  previewContent?: Uint8Array | ArrayBuffer | PreviewContentRange;
+  chunkSize?: number;
+}
+
+export interface PreviewContentRange {
+  offset: number;
+  bytes: Uint8Array | ArrayBuffer;
 }
 
 function randomBytes(length: number): Uint8Array {
@@ -76,23 +103,222 @@ function hashToBytes(hash: string): Uint8Array {
   return bytes;
 }
 
+function uint32Bytes(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, false);
+  return bytes;
+}
+
+function uint64Bytes(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Proof offset must be a safe non-negative integer');
+  }
+
+  const bytes = new Uint8Array(8);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, Math.floor(value / 0x100000000), false);
+  view.setUint32(4, value >>> 0, false);
+  return bytes;
+}
+
 function previewLeaf(previewPayload: Uint8Array): string {
   return taggedHash(`${STASH_PROOF_VERSION}:preview`, [previewPayload]);
 }
 
-function contentLeaf(content: Uint8Array, salt: Uint8Array): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:content`, [salt, content]);
+function publicContentLeaf(offset: number, content: Uint8Array): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:content-leaf-public`, [
+    uint64Bytes(offset),
+    uint32Bytes(content.length),
+    content,
+  ]);
 }
 
-function rootHash(previewHash: string, contentHash: string): string {
+function privateContentLeaf(offset: number, content: Uint8Array, salt: Uint8Array): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:content-leaf-private`, [
+    uint64Bytes(offset),
+    uint32Bytes(content.length),
+    salt,
+    content,
+  ]);
+}
+
+function merkleParent(left: string, right: string): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:merkle-parent`, [
+    hashToBytes(left),
+    hashToBytes(right),
+  ]);
+}
+
+function rootHash(previewHash: string, contentMerkleRoot: string): string {
   return taggedHash(`${STASH_PROOF_VERSION}:root`, [
     hashToBytes(previewHash),
-    hashToBytes(contentHash),
+    hashToBytes(contentMerkleRoot),
   ]);
+}
+
+function validateChunkSize(chunkSize: number): void {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1024 || chunkSize > 1024 * 1024) {
+    throw new Error('Content chunk size must be between 1 KiB and 1 MiB');
+  }
+}
+
+function bytesEqualAt(content: Uint8Array, offset: number, expected: Uint8Array): boolean {
+  if (offset + expected.length > content.length) return false;
+
+  for (let i = 0; i < expected.length; i += 1) {
+    if (content[offset + i] !== expected[i]) return false;
+  }
+
+  return true;
+}
+
+function normalizePreviewRange(
+  content: Uint8Array,
+  previewContent: Uint8Array | ArrayBuffer | PreviewContentRange | undefined
+): { offset: number; bytes: Uint8Array } | undefined {
+  if (!previewContent) return undefined;
+
+  const range =
+    previewContent instanceof Uint8Array || previewContent instanceof ArrayBuffer
+      ? { offset: 0, bytes: toBytes(previewContent) }
+      : { offset: previewContent.offset, bytes: toBytes(previewContent.bytes) };
+
+  if (
+    !Number.isSafeInteger(range.offset) ||
+    range.offset < 0 ||
+    range.bytes.length === 0 ||
+    range.offset + range.bytes.length > content.length
+  ) {
+    throw new Error('Preview content range is outside the file');
+  }
+
+  if (!bytesEqualAt(content, range.offset, range.bytes)) {
+    throw new Error('Preview content must match the file at its declared offset');
+  }
+
+  return range;
+}
+
+function contentLeaves(
+  content: Uint8Array,
+  salt: Uint8Array,
+  previewRange: { offset: number; bytes: Uint8Array } | undefined,
+  chunkSize: number
+): { leaves: string[]; previewLeafIndex?: number } {
+  const leaves: string[] = [];
+  let previewLeafIndex: number | undefined;
+
+  const addPrivateLeaves = (start: number, end: number) => {
+    let offset = start;
+    while (offset < end) {
+      const nextOffset = Math.min(offset + chunkSize, end);
+      leaves.push(privateContentLeaf(offset, content.slice(offset, nextOffset), salt));
+      offset = nextOffset;
+    }
+  };
+
+  if (previewRange) {
+    addPrivateLeaves(0, previewRange.offset);
+    previewLeafIndex = leaves.length;
+    leaves.push(publicContentLeaf(previewRange.offset, previewRange.bytes));
+    addPrivateLeaves(previewRange.offset + previewRange.bytes.length, content.length);
+  } else {
+    addPrivateLeaves(0, content.length);
+  }
+
+  if (leaves.length === 0) {
+    leaves.push(privateContentLeaf(0, new Uint8Array(), salt));
+  }
+
+  return { leaves, previewLeafIndex };
+}
+
+function merkleRoot(leaves: string[]): string {
+  let level = leaves;
+
+  while (level.length > 1) {
+    const nextLevel: string[] = [];
+
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 >= level.length) {
+        nextLevel.push(level[i]);
+      } else {
+        nextLevel.push(merkleParent(level[i], level[i + 1]));
+      }
+    }
+
+    level = nextLevel;
+  }
+
+  return level[0];
+}
+
+function merklePath(leaves: string[], leafIndex: number): MerkleProofStep[] {
+  const path: MerkleProofStep[] = [];
+  let level = leaves;
+  let index = leafIndex;
+
+  while (level.length > 1) {
+    const isRight = index % 2 === 1;
+    const siblingIndex = isRight ? index - 1 : index + 1;
+
+    if (siblingIndex < level.length) {
+      path.push({
+        side: isRight ? 'left' : 'right',
+        hash: level[siblingIndex],
+      });
+    }
+
+    const nextLevel: string[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      if (i + 1 >= level.length) {
+        nextLevel.push(level[i]);
+      } else {
+        nextLevel.push(merkleParent(level[i], level[i + 1]));
+      }
+    }
+
+    level = nextLevel;
+    index = Math.floor(index / 2);
+  }
+
+  return path;
+}
+
+function verifyMerklePath(leafHash: string, path: MerkleProofStep[], root: string): boolean {
+  let current = leafHash;
+
+  for (const step of path) {
+    current =
+      step.side === 'left' ? merkleParent(step.hash, current) : merkleParent(current, step.hash);
+  }
+
+  return current === root;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isPreviewInclusionProof(value: unknown): value is PreviewInclusionProof {
+  if (!isRecord(value)) return false;
+
+  return (
+    Number.isSafeInteger(value.offset) &&
+    (value.offset as number) >= 0 &&
+    Number.isInteger(value.length) &&
+    (value.length as number) > 0 &&
+    typeof value.leafHash === 'string' &&
+    isHash(value.leafHash) &&
+    Array.isArray(value.path) &&
+    value.path.every(
+      (step) =>
+        isRecord(step) &&
+        (step.side === 'left' || step.side === 'right') &&
+        typeof step.hash === 'string' &&
+        isHash(step.hash)
+    )
+  );
 }
 
 function isProofShape(proof: unknown): proof is StashProof {
@@ -101,32 +327,55 @@ function isProofShape(proof: unknown): proof is StashProof {
   return (
     proof.version === STASH_PROOF_VERSION &&
     typeof proof.previewHash === 'string' &&
-    typeof proof.contentHash === 'string' &&
+    typeof proof.contentMerkleRoot === 'string' &&
     typeof proof.root === 'string' &&
+    Number.isInteger(proof.contentLength) &&
+    (proof.contentLength as number) >= 0 &&
+    Number.isInteger(proof.chunkSize) &&
     isHash(proof.previewHash) &&
-    isHash(proof.contentHash) &&
-    isHash(proof.root)
+    isHash(proof.contentMerkleRoot) &&
+    isHash(proof.root) &&
+    (proof.previewInclusion === undefined || isPreviewInclusionProof(proof.previewInclusion))
   );
 }
 
 export function createStashProof(
   previewPayload: Uint8Array | ArrayBuffer,
   content: Uint8Array | ArrayBuffer,
-  salt: Uint8Array = randomBytes(SALT_LENGTH)
+  options: CreateStashProofOptions = {}
 ): StashProofBundle {
+  const salt = options.salt ?? randomBytes(SALT_LENGTH);
   if (salt.length !== SALT_LENGTH) {
     throw new Error(`Content salt must be ${SALT_LENGTH} bytes`);
   }
 
+  const chunkSize = options.chunkSize ?? DEFAULT_CONTENT_CHUNK_SIZE;
+  validateChunkSize(chunkSize);
+
+  const contentBytes = toBytes(content);
+  const previewRange = normalizePreviewRange(contentBytes, options.previewContent);
   const previewHash = previewLeaf(toBytes(previewPayload));
-  const contentHash = contentLeaf(toBytes(content), salt);
+  const { leaves, previewLeafIndex } = contentLeaves(contentBytes, salt, previewRange, chunkSize);
+  const contentMerkleRoot = merkleRoot(leaves);
+  const previewInclusion =
+    previewRange && previewLeafIndex !== undefined
+      ? {
+          offset: previewRange.offset,
+          length: previewRange.bytes.length,
+          leafHash: leaves[previewLeafIndex],
+          path: merklePath(leaves, previewLeafIndex),
+        }
+      : undefined;
 
   return {
     proof: {
       version: STASH_PROOF_VERSION,
       previewHash,
-      contentHash,
-      root: rootHash(previewHash, contentHash),
+      contentMerkleRoot,
+      contentLength: contentBytes.length,
+      chunkSize,
+      previewInclusion,
+      root: rootHash(previewHash, contentMerkleRoot),
     },
     secret: {
       contentSalt: bytesToHex(salt),
@@ -140,7 +389,29 @@ export function verifyPreview(previewPayload: Uint8Array | ArrayBuffer, proof: u
   const previewHash = previewLeaf(toBytes(previewPayload));
   if (previewHash !== proof.previewHash) return false;
 
-  return rootHash(proof.previewHash, proof.contentHash) === proof.root;
+  return rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root;
+}
+
+export function verifyPreviewInclusion(
+  previewContent: Uint8Array | ArrayBuffer,
+  proof: unknown
+): boolean {
+  if (!isProofShape(proof) || !proof.previewInclusion) return false;
+
+  const previewBytes = toBytes(previewContent);
+  if (
+    proof.previewInclusion.length !== previewBytes.length ||
+    proof.previewInclusion.offset + proof.previewInclusion.length > proof.contentLength
+  ) {
+    return false;
+  }
+
+  const leafHash = publicContentLeaf(proof.previewInclusion.offset, previewBytes);
+  return (
+    leafHash === proof.previewInclusion.leafHash &&
+    verifyMerklePath(leafHash, proof.previewInclusion.path, proof.contentMerkleRoot) &&
+    rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root
+  );
 }
 
 export function verifyUnlockedFile(
@@ -157,9 +428,39 @@ export function verifyUnlockedFile(
     return false;
   }
 
-  const salt = hashToBytes(secret.contentSalt);
-  const contentHash = contentLeaf(toBytes(content), salt);
-  if (contentHash !== proof.contentHash) return false;
+  if (!validateChunkSizeForVerify(proof.chunkSize)) return false;
 
-  return rootHash(proof.previewHash, proof.contentHash) === proof.root;
+  const salt = hashToBytes(secret.contentSalt);
+  const contentBytes = toBytes(content);
+  if (contentBytes.length !== proof.contentLength) return false;
+
+  const previewRange = proof.previewInclusion
+    ? {
+        offset: proof.previewInclusion.offset,
+        bytes: contentBytes.slice(
+          proof.previewInclusion.offset,
+          proof.previewInclusion.offset + proof.previewInclusion.length
+        ),
+      }
+    : undefined;
+  const { leaves } = contentLeaves(contentBytes, salt, previewRange, proof.chunkSize);
+  const contentMerkleRoot = merkleRoot(leaves);
+  if (contentMerkleRoot !== proof.contentMerkleRoot) return false;
+
+  if (proof.previewInclusion) {
+    if (!previewRange || !verifyPreviewInclusion(previewRange.bytes, proof)) {
+      return false;
+    }
+  }
+
+  return rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root;
+}
+
+function validateChunkSizeForVerify(chunkSize: number): boolean {
+  try {
+    validateChunkSize(chunkSize);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/client/src/lib/stashProof.ts
+++ b/client/src/lib/stashProof.ts
@@ -1,0 +1,165 @@
+import { bytesToHex, sha256 } from './crypto.js';
+
+export const STASH_PROOF_VERSION = 'stashu-preview-v1' as const;
+
+const SALT_LENGTH = 32;
+const MAX_FRAME_LENGTH = 0xffffffff;
+const encoder = new TextEncoder();
+
+export interface StashProof {
+  version: typeof STASH_PROOF_VERSION;
+  root: string;
+  previewHash: string;
+  contentHash: string;
+}
+
+export interface StashProofSecret {
+  contentSalt: string;
+}
+
+export interface StashProofBundle {
+  proof: StashProof;
+  secret: StashProofSecret;
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function frame(part: Uint8Array): Uint8Array {
+  if (part.length > MAX_FRAME_LENGTH) {
+    throw new Error('Proof frame is too large');
+  }
+
+  const framed = new Uint8Array(4 + part.length);
+  new DataView(framed.buffer).setUint32(0, part.length, false);
+  framed.set(part, 4);
+  return framed;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+
+  return result;
+}
+
+function taggedHash(tag: string, parts: Uint8Array[]): string {
+  return sha256(concat([frame(encoder.encode(tag)), ...parts.map(frame)]));
+}
+
+function isHash(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value);
+}
+
+function hashToBytes(hash: string): Uint8Array {
+  if (!isHash(hash)) {
+    throw new Error('Invalid proof hash');
+  }
+
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hash.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function previewLeaf(previewPayload: Uint8Array): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:preview`, [previewPayload]);
+}
+
+function contentLeaf(content: Uint8Array, salt: Uint8Array): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:content`, [salt, content]);
+}
+
+function rootHash(previewHash: string, contentHash: string): string {
+  return taggedHash(`${STASH_PROOF_VERSION}:root`, [
+    hashToBytes(previewHash),
+    hashToBytes(contentHash),
+  ]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isProofShape(proof: unknown): proof is StashProof {
+  if (!isRecord(proof)) return false;
+
+  return (
+    proof.version === STASH_PROOF_VERSION &&
+    typeof proof.previewHash === 'string' &&
+    typeof proof.contentHash === 'string' &&
+    typeof proof.root === 'string' &&
+    isHash(proof.previewHash) &&
+    isHash(proof.contentHash) &&
+    isHash(proof.root)
+  );
+}
+
+export function createStashProof(
+  previewPayload: Uint8Array | ArrayBuffer,
+  content: Uint8Array | ArrayBuffer,
+  salt: Uint8Array = randomBytes(SALT_LENGTH)
+): StashProofBundle {
+  if (salt.length !== SALT_LENGTH) {
+    throw new Error(`Content salt must be ${SALT_LENGTH} bytes`);
+  }
+
+  const previewHash = previewLeaf(toBytes(previewPayload));
+  const contentHash = contentLeaf(toBytes(content), salt);
+
+  return {
+    proof: {
+      version: STASH_PROOF_VERSION,
+      previewHash,
+      contentHash,
+      root: rootHash(previewHash, contentHash),
+    },
+    secret: {
+      contentSalt: bytesToHex(salt),
+    },
+  };
+}
+
+export function verifyPreview(previewPayload: Uint8Array | ArrayBuffer, proof: unknown): boolean {
+  if (!isProofShape(proof)) return false;
+
+  const previewHash = previewLeaf(toBytes(previewPayload));
+  if (previewHash !== proof.previewHash) return false;
+
+  return rootHash(proof.previewHash, proof.contentHash) === proof.root;
+}
+
+export function verifyUnlockedFile(
+  content: Uint8Array | ArrayBuffer,
+  proof: unknown,
+  secret: unknown
+): boolean {
+  if (
+    !isProofShape(proof) ||
+    !isRecord(secret) ||
+    typeof secret.contentSalt !== 'string' ||
+    !/^[0-9a-f]{64}$/.test(secret.contentSalt)
+  ) {
+    return false;
+  }
+
+  const salt = hashToBytes(secret.contentSalt);
+  const contentHash = contentLeaf(toBytes(content), salt);
+  if (contentHash !== proof.contentHash) return false;
+
+  return rootHash(proof.previewHash, proof.contentHash) === proof.root;
+}

--- a/client/src/lib/useStash.ts
+++ b/client/src/lib/useStash.ts
@@ -4,6 +4,13 @@ import { uploadToBlossom, getBlossomServer, mirrorToBackupServers } from './blos
 import { getPublicKey } from './nostr';
 import { createStash } from './api';
 import { hasIdentity, hasAcknowledgedRecovery } from './identity';
+import {
+  decodeGeneratedPreviewBytes,
+  generatePreviewFromBytes,
+  serializeGeneratedPreviewPayload,
+  type TextLineLimit,
+} from './generatedPreview';
+import { createStashProof } from './stashProof';
 
 export type StashStatus = 'idle' | 'encrypting' | 'uploading' | 'creating' | 'done' | 'error';
 
@@ -18,6 +25,14 @@ export interface StashOptions {
   title: string;
   description?: string;
   priceSats: number;
+  peekMode?: 'none' | 'auto' | 'excerpt';
+  previewLineLimit?: TextLineLimit;
+  previewMaxChars?: number;
+  previewRatio?: number;
+  peekExcerpt?: {
+    offset: number;
+    text: string;
+  };
 }
 
 export function useStash() {
@@ -38,6 +53,37 @@ export function useStash() {
     try {
       setState((s) => ({ ...s, status: 'encrypting', progress: 20 }));
       const fileData = await readFileAsArrayBuffer(file);
+      const fileBytes = new Uint8Array(fileData);
+      const generatedPreview = generatePreviewFromBytes(
+        {
+          fileName: file.name,
+          fileType: file.type,
+          fileSize: file.size,
+          content: fileBytes,
+        },
+        {
+          mode: options.peekMode ?? 'none',
+          lineLimit: options.previewLineLimit,
+          maxChars: options.previewMaxChars,
+          maxPreviewRatio: options.previewRatio,
+          excerpt: options.peekExcerpt,
+        }
+      );
+      const previewContent =
+        generatedPreview.kind === 'text-peek'
+          ? {
+              offset: (generatedPreview.metadata as { offset: number }).offset,
+              bytes: decodeGeneratedPreviewBytes(generatedPreview),
+            }
+          : undefined;
+      const { proof: previewProof, secret: previewSecret } = createStashProof(
+        serializeGeneratedPreviewPayload(generatedPreview),
+        fileBytes,
+        {
+          previewContent:
+            previewContent && previewContent.bytes.length > 0 ? previewContent : undefined,
+        }
+      );
       const { ciphertext, nonce, key } = await encryptFile(fileData);
       const secretKey = `${toBase64(nonce)}:${toBase64(key)}`;
 
@@ -59,6 +105,9 @@ export function useStash() {
         description: options.description,
         fileName: file.name,
         fileSize: file.size,
+        generatedPreview,
+        previewProof,
+        previewSecret,
       });
 
       const shareUrl = `${window.location.origin}/s/${stashResult.id}`;

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -2,7 +2,8 @@ import { useState, useCallback } from 'react';
 import { getStashInfo, unlockStash, claimStash } from './api';
 import { decryptFile, fromBase64 } from './crypto';
 import { fetchFromBlossomWithFallback } from './blossom';
-import type { StashPublicInfo } from '../../../shared/types';
+import { verifyUnlockedStashFile } from './verifiedPreview';
+import type { StashProofSecret, StashPublicInfo } from '../../../shared/types';
 
 export type UnlockStatus =
   | 'loading'
@@ -19,6 +20,7 @@ export interface UnlockState {
   error: string | null;
   downloadUrl: string | null;
   fileName: string | null;
+  blobSha256: string | null;
 }
 
 export function useUnlock(stashId: string) {
@@ -28,6 +30,7 @@ export function useUnlock(stashId: string) {
     error: null,
     downloadUrl: null,
     fileName: null,
+    blobSha256: null,
   });
 
   const decryptAndFinish = useCallback(
@@ -36,6 +39,7 @@ export function useUnlock(stashId: string) {
       blobUrl: string;
       blobSha256?: string;
       fileName?: string;
+      previewSecret?: StashProofSecret;
     }) => {
       setState((s) => ({ ...s, status: 'decrypting', error: null }));
 
@@ -49,19 +53,38 @@ export function useUnlock(stashId: string) {
       const key = fromBase64(keyB64);
 
       const plaintext = await decryptFile(ciphertext, key, nonce);
+      if (
+        state.stash?.previewProof &&
+        !verifyUnlockedStashFile(state.stash, plaintext, data.previewSecret)
+      ) {
+        throw new Error('Unlocked file did not match its preview proof');
+      }
 
       const blob = new Blob([plaintext]);
       const downloadUrl = URL.createObjectURL(blob);
       const fileName = data.fileName || state.stash?.title || 'download';
 
-      setState((s) => ({ ...s, status: 'done', downloadUrl, fileName }));
+      setState((s) => ({
+        ...s,
+        status: 'done',
+        downloadUrl,
+        fileName,
+        blobSha256: data.blobSha256 ?? null,
+      }));
     },
     [state.stash]
   );
 
   const loadStash = useCallback(async () => {
     try {
-      setState((s) => ({ ...s, status: 'loading', error: null }));
+      setState((s) => ({
+        ...s,
+        status: 'loading',
+        error: null,
+        downloadUrl: null,
+        fileName: null,
+        blobSha256: null,
+      }));
       const stash = await getStashInfo(stashId);
       // If a claim token exists, go straight to 'claiming' to avoid flashing payment UI
       const hasClaimToken = !!localStorage.getItem(`stashu-claim-${stashId}`);
@@ -91,7 +114,11 @@ export function useUnlock(stashId: string) {
         localStorage.removeItem(`stashu-claim-${stashId}`);
       }
       // For transient errors (network, 500), keep the token for next attempt
-      setState((s) => ({ ...s, status: 'ready' }));
+      setState((s) => ({
+        ...s,
+        status: 'ready',
+        error: error instanceof Error ? error.message : 'Could not restore previous payment',
+      }));
       return false;
     }
   }, [stashId, decryptAndFinish]);
@@ -146,6 +173,7 @@ export function useUnlock(stashId: string) {
       blobSha256?: string;
       fileName?: string;
       claimToken?: string;
+      previewSecret?: StashProofSecret;
     }) => {
       try {
         // Store claim token for re-download
@@ -175,6 +203,7 @@ export function useUnlock(stashId: string) {
       error: null,
       downloadUrl: null,
       fileName: null,
+      blobSha256: null,
     });
   }, [state.downloadUrl]);
 

--- a/client/src/lib/verifiedPreview.test.ts
+++ b/client/src/lib/verifiedPreview.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeGeneratedPreviewBytes,
+  generatePreviewFromBytes,
+  serializeGeneratedPreviewPayload,
+} from './generatedPreview.js';
+import { createStashProof } from './stashProof.js';
+import {
+  decodeTextPreview,
+  verifyGeneratedPreviewBundle,
+  verifyUnlockedStashFile,
+} from './verifiedPreview.js';
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+describe('verified preview helpers', () => {
+  it('verifies a generated text preview against its Merkle proof', () => {
+    const content = bytes('first lines\npaid-only section');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { mode: 'auto', maxChars: 10, maxPreviewRatio: 0.5 }
+    );
+    const { proof } = createStashProof(serializeGeneratedPreviewPayload(preview), content, {
+      previewContent: decodeGeneratedPreviewBytes(preview),
+      salt: new Uint8Array(32).fill(1),
+    });
+
+    expect(verifyGeneratedPreviewBundle(preview, proof)).toEqual({
+      state: 'verified',
+      text: 'first line',
+    });
+  });
+
+  it('rejects a preview payload that was changed after proof generation', () => {
+    const content = bytes('real preview\nhidden');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { mode: 'auto', maxChars: 8, maxPreviewRatio: 0.5 }
+    );
+    const { proof } = createStashProof(serializeGeneratedPreviewPayload(preview), content, {
+      previewContent: decodeGeneratedPreviewBytes(preview),
+    });
+
+    const tamperedPreview = { ...preview, fileName: 'other.md' };
+
+    expect(verifyGeneratedPreviewBundle(tamperedPreview, proof)).toEqual({ state: 'invalid' });
+  });
+
+  it('rejects a text peek that is not proven as part of the file', () => {
+    const content = bytes('preview\nhidden');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { mode: 'auto', maxChars: 7, maxPreviewRatio: 0.5 }
+    );
+    const { proof } = createStashProof(serializeGeneratedPreviewPayload(preview), content);
+
+    expect(verifyGeneratedPreviewBundle(preview, proof)).toEqual({ state: 'invalid' });
+  });
+
+  it('verifies a picked excerpt from the middle of the file', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+    const offset = bytes('intro\n').length;
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      {
+        mode: 'excerpt',
+        maxPreviewRatio: 0.5,
+        excerpt: {
+          offset,
+          text: 'safe excerpt',
+        },
+      }
+    );
+    const { proof, secret } = createStashProof(serializeGeneratedPreviewPayload(preview), content, {
+      previewContent: { offset, bytes: decodeGeneratedPreviewBytes(preview) },
+      salt: new Uint8Array(32).fill(3),
+    });
+
+    expect(verifyGeneratedPreviewBundle(preview, proof)).toEqual({
+      state: 'verified',
+      text: 'safe excerpt',
+    });
+    expect(verifyUnlockedStashFile({ previewProof: proof }, content, secret)).toBe(true);
+  });
+
+  it('verifies the unlocked file with the revealed preview secret', () => {
+    const content = bytes('preview\nhidden');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      { mode: 'auto', maxChars: 7, maxPreviewRatio: 0.5 }
+    );
+    const { proof, secret } = createStashProof(serializeGeneratedPreviewPayload(preview), content, {
+      previewContent: decodeGeneratedPreviewBytes(preview),
+      salt: new Uint8Array(32).fill(2),
+    });
+
+    expect(verifyUnlockedStashFile({ previewProof: proof }, content, secret)).toBe(true);
+    expect(verifyUnlockedStashFile({ previewProof: proof }, bytes('different'), secret)).toBe(
+      false
+    );
+  });
+
+  it('decodes display text for text previews', () => {
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'notes.txt',
+        fileType: 'text/plain',
+        fileSize: 5,
+        content: bytes('hello'),
+      },
+      { mode: 'auto', maxChars: 2, maxPreviewRatio: 0.5 }
+    );
+
+    expect(decodeTextPreview(preview)).toBe('he');
+  });
+});

--- a/client/src/lib/verifiedPreview.ts
+++ b/client/src/lib/verifiedPreview.ts
@@ -1,0 +1,69 @@
+import type {
+  GeneratedPreviewPayload,
+  StashProof,
+  StashProofSecret,
+  StashPublicInfo,
+} from '../../../shared/types';
+import { decodeGeneratedPreviewBytes, serializeGeneratedPreviewPayload } from './generatedPreview';
+import { verifyPreview, verifyPreviewInclusion, verifyUnlockedFile } from './stashProof';
+
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+export type PreviewVerificationState = 'missing' | 'verified' | 'invalid';
+
+export interface PreviewVerificationResult {
+  state: PreviewVerificationState;
+  text?: string;
+}
+
+export function decodeTextPreview(payload: GeneratedPreviewPayload): string | undefined {
+  if (payload.kind !== 'text-peek') return undefined;
+  return decoder.decode(decodeGeneratedPreviewBytes(payload));
+}
+
+export function verifyGeneratedPreviewBundle(
+  generatedPreview: GeneratedPreviewPayload | undefined,
+  previewProof: StashProof | undefined
+): PreviewVerificationResult {
+  if (!generatedPreview && !previewProof) {
+    return { state: 'missing' };
+  }
+
+  if (!generatedPreview || !previewProof) {
+    return { state: 'invalid' };
+  }
+
+  try {
+    const serializedPreview = serializeGeneratedPreviewPayload(generatedPreview);
+    if (!verifyPreview(serializedPreview, previewProof)) {
+      return { state: 'invalid' };
+    }
+
+    if (generatedPreview.kind === 'file-summary') {
+      return { state: previewProof.previewInclusion ? 'invalid' : 'verified' };
+    }
+
+    const previewBytes = decodeGeneratedPreviewBytes(generatedPreview);
+    if (previewBytes.length > 0 && !verifyPreviewInclusion(previewBytes, previewProof)) {
+      return { state: 'invalid' };
+    }
+
+    return {
+      state: 'verified',
+      text: decoder.decode(previewBytes),
+    };
+  } catch {
+    return { state: 'invalid' };
+  }
+}
+
+export function verifyUnlockedStashFile(
+  stash: Pick<StashPublicInfo, 'previewProof'>,
+  content: ArrayBuffer | Uint8Array,
+  previewSecret: StashProofSecret | undefined
+): boolean {
+  if (!stash.previewProof) return true;
+  if (!previewSecret) return false;
+
+  return verifyUnlockedFile(content, stash.previewProof, previewSecret);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,33 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import App from './App.tsx';
-import {
-  SellPage,
-  UnlockPage,
-  DashboardPage,
-  RestorePage,
-  SettingsPage,
-  StorefrontPage,
-  ToastProvider,
-} from './components';
-import NotFoundPage from './components/NotFoundPage.tsx';
+import { BrowserRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
+import { ToastProvider } from './components';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ToastProvider>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<App />} />
-          <Route path="/sell" element={<SellPage />} />
-          <Route path="/s/:id" element={<UnlockPage />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/restore" element={<RestorePage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/p/:npub" element={<StorefrontPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
+        <AppRoutes />
       </BrowserRouter>
     </ToastProvider>
   </StrictMode>

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -374,6 +374,32 @@ const currentVersion = (
         console.log('🏪 Added show_in_storefront column to stashes.');
       },
     },
+    {
+      version: 9,
+      name: 'add generated preview proof fields to stashes',
+      run: () => {
+        db.exec(`ALTER TABLE stashes ADD COLUMN generated_preview_payload TEXT DEFAULT NULL`);
+        db.exec(`ALTER TABLE stashes ADD COLUMN preview_proof TEXT DEFAULT NULL`);
+        db.exec(`ALTER TABLE stashes ADD COLUMN preview_secret TEXT DEFAULT NULL`);
+        console.log('🔎 Added generated preview proof fields to stashes.');
+      },
+    },
+    {
+      version: 10,
+      name: 'encrypt plaintext blob urls',
+      run: () => {
+        const rows = db.prepare(`SELECT id, blob_url FROM stashes`).all() as Array<{
+          id: string;
+          blob_url: string;
+        }>;
+        if (rows.length === 0) return;
+        const update = db.prepare(`UPDATE stashes SET blob_url = ? WHERE id = ?`);
+        for (const row of rows) {
+          update.run(encrypt(row.blob_url), row.id);
+        }
+        console.log(`🔐 Encrypted ${rows.length} blob URL(s).`);
+      },
+    },
   ];
 
   // Run pending migrations in a transaction

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -2,14 +2,15 @@
  * Database row types — mirror the actual SQLite column names (snake_case).
  * Use Pick<T, ...> when a query selects only a subset of columns.
  *
- * Encrypted columns: secret_key, title, description, file_name (stashes);
+ * Encrypted columns: blob_url, secret_key, title, description, file_name,
+ *                    generated_preview_payload, preview_proof, preview_secret (stashes);
  *                    seller_token (payments); ln_address (seller_settings, settlement_log).
  * Callers must decrypt() before use and encrypt() before insert/update.
  */
 
 export interface StashRow {
   id: string;
-  blob_url: string;
+  blob_url: string; // encrypted
   blob_sha256: string | null;
   secret_key: string; // encrypted
   key_backup: string | null;
@@ -20,6 +21,9 @@ export interface StashRow {
   file_name: string; // encrypted
   file_size: number;
   preview_url: string | null;
+  generated_preview_payload: string | null; // encrypted public metadata
+  preview_proof: string | null; // encrypted public metadata
+  preview_secret: string | null; // encrypted
   show_in_storefront: number;
   created_at: number;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,9 +17,20 @@ import { recoverPendingMelts, recoverMintFailures } from './lib/recovery.js';
 
 const app = new Hono();
 
-const corsOrigins = process.env.CORS_ORIGINS
-  ? process.env.CORS_ORIGINS.split(',')
-  : ['http://localhost:5173', 'http://localhost:5174'];
+const configuredCorsOrigins =
+  process.env.CORS_ORIGINS?.split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean) ?? [];
+const localDevOrigins = [
+  'http://localhost:5173',
+  'http://localhost:5174',
+  'http://127.0.0.1:5173',
+  'http://127.0.0.1:5174',
+];
+const corsOrigins =
+  process.env.NODE_ENV === 'production' && configuredCorsOrigins.length > 0
+    ? configuredCorsOrigins
+    : [...new Set([...configuredCorsOrigins, ...localDevOrigins])];
 
 // Security headers
 app.use('*', async (c, next) => {

--- a/server/src/routes/claim.test.ts
+++ b/server/src/routes/claim.test.ts
@@ -66,7 +66,7 @@ function insertStash(id = TEST_STASH.id) {
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
-    TEST_STASH.blobUrl,
+    encrypt(TEST_STASH.blobUrl),
     encrypt(TEST_STASH.secretKey),
     TEST_STASH.sellerPubkey,
     TEST_STASH.priceSats,

--- a/server/src/routes/pay.test.ts
+++ b/server/src/routes/pay.test.ts
@@ -26,15 +26,19 @@ const app = new Hono();
 app.route('/api/pay', payRoutes);
 
 const TEST_STASH_ID = 'stash-pay-001';
+const PREVIEW_SECRET = { contentSalt: 'd'.repeat(64) };
 
-function insertStash(id = TEST_STASH_ID) {
+function insertStash(id = TEST_STASH_ID, previewSecret?: typeof PREVIEW_SECRET) {
   db.prepare(
-    `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO stashes (
+       id, blob_url, secret_key, preview_secret, seller_pubkey, price_sats, title, file_name, file_size
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
-    'https://blossom.example.com/blob',
+    encrypt('https://blossom.example.com/blob'),
     encrypt('pay-secret-key'),
+    previewSecret ? encrypt(JSON.stringify(previewSecret)) : null,
     'seller-pubkey',
     100,
     encrypt('Test'),
@@ -78,7 +82,7 @@ describe('GET /api/pay/:id/status/:quoteId', () => {
   });
 
   it('returns unlock data with claimToken when already paid', async () => {
-    insertStash();
+    insertStash(TEST_STASH_ID, PREVIEW_SECRET);
     db.prepare(
       `INSERT INTO payments (id, stash_id, status, token_hash, seller_token, paid_at)
        VALUES (?, ?, 'paid', ?, ?, ?)`
@@ -97,6 +101,7 @@ describe('GET /api/pay/:id/status/:quoteId', () => {
     assert.equal(data.secretKey, 'pay-secret-key');
     assert.equal(data.blobUrl, 'https://blossom.example.com/blob');
     assert.equal(data.fileName, 'file.pdf');
+    assert.deepEqual(data.previewSecret, PREVIEW_SECRET);
     assert.ok(data.claimToken, 'should return a claimToken');
     assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
   });

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -8,7 +8,12 @@ import {
   verifyAndSwapToken,
 } from '../lib/cashu.js';
 import { encrypt, decrypt } from '../lib/encryption.js';
-import type { PayInvoiceResponse, PayStatusResponse, APIResponse } from '../../../shared/types.js';
+import type {
+  PayInvoiceResponse,
+  PayStatusResponse,
+  StashProofSecret,
+  APIResponse,
+} from '../../../shared/types.js';
 import type { StashRow, PaymentRow } from '../db/types.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 
@@ -28,6 +33,10 @@ function ensureClaimToken(
     paymentId
   );
   return claimToken;
+}
+
+function decryptPreviewSecret(value: string | null): StashProofSecret | undefined {
+  return value ? (JSON.parse(decrypt(value)) as StashProofSecret) : undefined;
 }
 
 export const payRoutes = new Hono();
@@ -98,8 +107,13 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
     // Already processed — return the unlock data
     if (existingPayment.status === 'paid') {
       const stash = db
-        .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
-        .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'>;
+        .prepare(
+          'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name FROM stashes WHERE id = ?'
+        )
+        .get(stashId) as Pick<
+        StashRow,
+        'secret_key' | 'blob_url' | 'blob_sha256' | 'preview_secret' | 'file_name'
+      >;
 
       const claimToken = ensureClaimToken(existingPayment, paymentId);
 
@@ -108,9 +122,10 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         data: {
           paid: true,
           secretKey: decrypt(stash.secret_key),
-          blobUrl: stash.blob_url,
+          blobUrl: decrypt(stash.blob_url),
           blobSha256: stash.blob_sha256 ?? undefined,
           fileName: decrypt(stash.file_name),
+          previewSecret: decryptPreviewSecret(stash.preview_secret),
           claimToken,
         },
       });
@@ -140,8 +155,13 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
 
       if (current?.status === 'paid') {
         const stash = db
-          .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
-          .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'>;
+          .prepare(
+            'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name FROM stashes WHERE id = ?'
+          )
+          .get(stashId) as Pick<
+          StashRow,
+          'secret_key' | 'blob_url' | 'blob_sha256' | 'preview_secret' | 'file_name'
+        >;
 
         const paidRow = db
           .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
@@ -156,9 +176,10 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           data: {
             paid: true,
             secretKey: decrypt(stash.secret_key),
-            blobUrl: stash.blob_url,
+            blobUrl: decrypt(stash.blob_url),
             blobSha256: stash.blob_sha256 ?? undefined,
             fileName: decrypt(stash.file_name),
+            previewSecret: decryptPreviewSecret(stash.preview_secret),
             claimToken,
           },
         });
@@ -183,7 +204,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
 
     const stash = db
       .prepare(
-        'SELECT id, price_sats, secret_key, blob_url, blob_sha256, file_name, seller_pubkey FROM stashes WHERE id = ?'
+        'SELECT id, price_sats, secret_key, blob_url, blob_sha256, preview_secret, file_name, seller_pubkey FROM stashes WHERE id = ?'
       )
       .get(stashId) as Pick<
       StashRow,
@@ -192,6 +213,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
       | 'secret_key'
       | 'blob_url'
       | 'blob_sha256'
+      | 'preview_secret'
       | 'file_name'
       | 'seller_pubkey'
     > | null;
@@ -241,9 +263,10 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
         data: {
           paid: true,
           secretKey: decrypt(stash.secret_key),
-          blobUrl: stash.blob_url,
+          blobUrl: decrypt(stash.blob_url),
           blobSha256: stash.blob_sha256 ?? undefined,
           fileName: decrypt(stash.file_name),
+          previewSecret: decryptPreviewSecret(stash.preview_secret),
           claimToken,
         },
       });

--- a/server/src/routes/seller.test.ts
+++ b/server/src/routes/seller.test.ts
@@ -244,7 +244,30 @@ describe('POST /api/stash/:id/visibility', () => {
     assert.equal(res.status, 403);
   });
 
+  it('rejects visibility on while storefront is disabled', async () => {
+    const id = insertStash({ showInStorefront: 0 });
+    const path = `/api/stash/${id}/visibility`;
+    const res = await app.request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: auth('POST', path),
+      },
+      body: JSON.stringify({ showInStorefront: true }),
+    });
+    assert.equal(res.status, 409);
+    const body = await res.json();
+    assert.equal(body.success, false);
+    assert.match(body.error, /storefront/i);
+
+    const row = db.prepare('SELECT show_in_storefront FROM stashes WHERE id = ?').get(id) as {
+      show_in_storefront: number;
+    };
+    assert.equal(row.show_in_storefront, 0);
+  });
+
   it('toggles visibility on', async () => {
+    enableStorefront(pk);
     const id = insertStash({ showInStorefront: 0 });
     const path = `/api/stash/${id}/visibility`;
     const res = await app.request(path, {

--- a/server/src/routes/seller.test.ts
+++ b/server/src/routes/seller.test.ts
@@ -36,11 +36,38 @@ function auth(method: string, path: string) {
   return makeNip98Header(method, `http://localhost${path}`, sk);
 }
 
-function insertStash(opts: { showInStorefront?: number; sellerPubkey?: string } = {}) {
+const PREVIEW_BUNDLE = {
+  generatedPreview: {
+    version: 'stashu-generated-preview-v1',
+    kind: 'file-summary',
+    fileName: 'file.pdf',
+    fileType: 'application/pdf',
+    fileSize: 1024,
+    contentType: 'application/octet-stream',
+    options: {},
+    metadata: { reason: 'unsupported-type' },
+    bytes: '',
+  },
+  previewProof: {
+    version: 'stashu-preview-v1',
+    root: 'a'.repeat(64),
+    previewHash: 'b'.repeat(64),
+    contentMerkleRoot: 'c'.repeat(64),
+    contentLength: 1024,
+    chunkSize: 65_536,
+  },
+};
+
+function insertStash(
+  opts: { showInStorefront?: number; sellerPubkey?: string; withPreviewProof?: boolean } = {}
+) {
   const id = crypto.randomUUID();
   db.prepare(
-    `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size, show_in_storefront, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())`
+    `INSERT INTO stashes (
+       id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name,
+       file_size, generated_preview_payload, preview_proof, show_in_storefront, created_at
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())`
   ).run(
     id,
     'https://blossom.example.com/abc',
@@ -50,6 +77,8 @@ function insertStash(opts: { showInStorefront?: number; sellerPubkey?: string } 
     encrypt('Test Stash'),
     encrypt('file.pdf'),
     1024,
+    opts.withPreviewProof ? encrypt(JSON.stringify(PREVIEW_BUNDLE.generatedPreview)) : null,
+    opts.withPreviewProof ? encrypt(JSON.stringify(PREVIEW_BUNDLE.previewProof)) : null,
     opts.showInStorefront ?? 0
   );
   return id;
@@ -130,6 +159,18 @@ describe('GET /api/seller/:pubkey', () => {
     assert.equal(body.data[0].title, 'Test Stash');
     assert.equal(body.data[0].fileName, 'file.pdf');
     assert.equal(body.data[0].priceSats, 100);
+  });
+
+  it('returns generated preview proof fields for visible stashes', async () => {
+    insertStash({ showInStorefront: 1, withPreviewProof: true });
+    enableStorefront(pk);
+
+    const res = await app.request(`/api/seller/${pk}`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body.data[0].generatedPreview, PREVIEW_BUNDLE.generatedPreview);
+    assert.deepEqual(body.data[0].previewProof, PREVIEW_BUNDLE.previewProof);
+    assert.equal(body.data[0].previewSecret, undefined);
   });
 
   it('does not return stashes from other sellers', async () => {

--- a/server/src/routes/seller.ts
+++ b/server/src/routes/seller.ts
@@ -1,10 +1,19 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
 import { decrypt } from '../lib/encryption.js';
-import type { StashPublicInfo, APIResponse } from '../../../shared/types.js';
+import type {
+  GeneratedPreviewPayload,
+  StashProof,
+  StashPublicInfo,
+  APIResponse,
+} from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const sellerRoutes = new Hono();
+
+function parseStoredJson<T>(value: string | null): T | undefined {
+  return value ? (JSON.parse(decrypt(value)) as T) : undefined;
+}
 
 // GET /api/seller/:pubkey - Get all stashes by a seller (public, no auth)
 sellerRoutes.get('/:pubkey', async (c) => {
@@ -46,7 +55,8 @@ sellerRoutes.get('/:pubkey', async (c) => {
     }
 
     const stmt = db.prepare(`
-      SELECT id, title, description, file_name, file_size, price_sats, preview_url, created_at
+      SELECT id, title, description, file_name, file_size, price_sats, preview_url,
+             generated_preview_payload, preview_proof, created_at
       FROM stashes
       WHERE seller_pubkey = ? AND show_in_storefront = 1
       ORDER BY created_at DESC
@@ -61,6 +71,8 @@ sellerRoutes.get('/:pubkey', async (c) => {
       | 'file_size'
       | 'price_sats'
       | 'preview_url'
+      | 'generated_preview_payload'
+      | 'preview_proof'
       | 'created_at'
     >[];
 
@@ -72,6 +84,8 @@ sellerRoutes.get('/:pubkey', async (c) => {
       fileSize: row.file_size,
       priceSats: row.price_sats,
       previewUrl: row.preview_url ?? undefined,
+      generatedPreview: parseStoredJson<GeneratedPreviewPayload>(row.generated_preview_payload),
+      previewProof: parseStoredJson<StashProof>(row.preview_proof),
     }));
 
     return c.json<APIResponse<StashPublicInfo[]>>({

--- a/server/src/routes/stash.test.ts
+++ b/server/src/routes/stash.test.ts
@@ -16,6 +16,7 @@ import assert from 'node:assert/strict';
 import { Hono } from 'hono';
 
 const db = (await import('../db/index.js')).default;
+const { decrypt } = await import('../lib/encryption.js');
 const { stashRoutes } = await import('./stash.js');
 const { requireAuth } = await import('../middleware/auth.js');
 const { createKeypair, makeNip98Header } = await import('../test/helpers.js');
@@ -40,6 +41,37 @@ function validBody() {
     priceSats: 100,
     fileSize: 1024,
   };
+}
+
+function validPreviewBundle(body = validBody()) {
+  return {
+    generatedPreview: {
+      version: 'stashu-generated-preview-v1',
+      kind: 'file-summary',
+      fileName: body.fileName,
+      fileType: 'application/pdf',
+      fileSize: body.fileSize,
+      contentType: 'application/octet-stream',
+      options: {},
+      metadata: { reason: 'unsupported-type' },
+      bytes: '',
+    },
+    previewProof: {
+      version: 'stashu-preview-v1',
+      root: 'a'.repeat(64),
+      previewHash: 'b'.repeat(64),
+      contentMerkleRoot: 'c'.repeat(64),
+      contentLength: body.fileSize,
+      chunkSize: 65_536,
+    },
+    previewSecret: {
+      contentSalt: 'd'.repeat(64),
+    },
+  };
+}
+
+function base64Url(value: string) {
+  return Buffer.from(value, 'utf8').toString('base64url');
 }
 
 async function createStash(body: Record<string, unknown> = validBody()) {
@@ -126,6 +158,460 @@ describe('POST /api/stash', () => {
     assert.ok(body.data.shareUrl.startsWith('/s/'));
   });
 
+  it('stores generated preview proof fields when provided', async () => {
+    const input = { ...validBody(), ...validPreviewBundle() };
+    const res = await createStash(input);
+    assert.equal(res.status, 201);
+    const { data } = await res.json();
+
+    const row = db
+      .prepare(
+        `SELECT generated_preview_payload, preview_proof, preview_secret
+         FROM stashes WHERE id = ?`
+      )
+      .get(data.id) as {
+      generated_preview_payload: string;
+      preview_proof: string;
+      preview_secret: string;
+    };
+
+    assert.notEqual(row.generated_preview_payload, JSON.stringify(input.generatedPreview));
+    assert.notEqual(row.preview_proof, JSON.stringify(input.previewProof));
+    assert.deepEqual(JSON.parse(decrypt(row.generated_preview_payload)), input.generatedPreview);
+    assert.deepEqual(JSON.parse(decrypt(row.preview_proof)), input.previewProof);
+    assert.notEqual(row.preview_secret, JSON.stringify(input.previewSecret));
+    assert.deepEqual(JSON.parse(decrypt(row.preview_secret)), input.previewSecret);
+  });
+
+  it('rejects partial preview bundles', async () => {
+    const res = await createStash({
+      ...validBody(),
+      generatedPreview: validPreviewBundle().generatedPreview,
+    });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /provided together/i);
+  });
+
+  it('rejects invalid preview proof hashes', async () => {
+    const bundle = validPreviewBundle();
+    const res = await createStash({
+      ...validBody(),
+      ...bundle,
+      previewProof: { ...bundle.previewProof, contentMerkleRoot: 'bad' },
+    });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /previewProof/i);
+  });
+
+  it('requires inclusion proof for text previews', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+    });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /inclusion/i);
+  });
+
+  it('rejects text preview metadata that does not match preview bytes', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 8,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 8,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /generatedPreview/i);
+  });
+
+  it('rejects text previews above the declared preview ratio', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.05,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 60,
+          previewBytes: 60,
+          truncated: true,
+        },
+        bytes: 'a'.repeat(80),
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 60,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /generatedPreview/i);
+  });
+
+  it('rejects text preview ratios above the server cap', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.75,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /generatedPreview/i);
+  });
+
+  it('accepts text previews with matching inclusion proof metadata', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 201);
+  });
+
+  it('rejects text previews whose bytes exceed the declared line limit', async () => {
+    const body = { ...validBody(), fileName: 'notes.md', fileSize: 1024 };
+    const bundle = validPreviewBundle(body);
+    const previewText = Array.from({ length: 11 }, (_, index) => `line ${index + 1}`).join('\n');
+    const previewBytes = Buffer.byteLength(previewText, 'utf8');
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/markdown',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'excerpt',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.5,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: previewBytes,
+          previewBytes,
+          truncated: true,
+        },
+        bytes: base64Url(previewText),
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: previewBytes,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /generatedPreview/i);
+  });
+
+  it('accepts seller-picked excerpt previews with a non-zero offset', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'excerpt',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 50,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 50,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 201);
+  });
+
+  it('rejects preview proof offsets that do not match generated preview metadata', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'excerpt',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 50,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /offset/i);
+  });
+
+  it('rejects oversized preview inclusion paths', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: Array.from({ length: 65 }, () => ({
+            side: 'right',
+            hash: 'f'.repeat(64),
+          })),
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /previewProof/i);
+  });
+
+  it('rejects generated preview metadata for a different file', async () => {
+    const bundle = validPreviewBundle();
+    const res = await createStash({
+      ...validBody(),
+      ...bundle,
+      generatedPreview: { ...bundle.generatedPreview, fileName: 'other.pdf' },
+    });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /generatedPreview/i);
+  });
+
   it('encrypts sensitive fields in DB', async () => {
     const input = validBody();
     const res = await createStash(input);
@@ -136,8 +622,10 @@ describe('POST /api/stash', () => {
       string
     >;
     assert.notEqual(row.title, input.title);
+    assert.notEqual(row.blob_url, input.blobUrl);
     assert.notEqual(row.secret_key, input.secretKey);
     assert.notEqual(row.file_name, input.fileName);
+    assert.equal(decrypt(row.blob_url), input.blobUrl);
     assert.ok(row.title.includes(':'), 'encrypted format is nonce:ciphertext');
   });
 
@@ -189,5 +677,19 @@ describe('GET /api/stash/:id', () => {
     const res = await app.request(`/api/stash/${created.id}`);
     const { data } = await res.json();
     assert.equal(data.description, 'A test description');
+  });
+
+  it('returns public generated preview proof but not preview secret', async () => {
+    const input = { ...validBody(), ...validPreviewBundle() };
+    const createRes = await createStash(input);
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}`);
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+
+    assert.deepEqual(data.generatedPreview, input.generatedPreview);
+    assert.deepEqual(data.previewProof, input.previewProof);
+    assert.equal(data.previewSecret, undefined);
   });
 });

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -459,6 +459,19 @@ stashRoutes.post('/:id/visibility', async (c) => {
       return c.json<APIResponse<never>>({ success: false, error: 'Not your stash' }, 403);
     }
 
+    if (body.showInStorefront) {
+      const settings = db
+        .prepare('SELECT storefront_enabled FROM seller_settings WHERE pubkey = ?')
+        .get(pubkey) as { storefront_enabled: number } | undefined;
+
+      if (settings?.storefront_enabled !== 1) {
+        return c.json<APIResponse<never>>(
+          { success: false, error: 'Enable your storefront before showing stashes publicly' },
+          409
+        );
+      }
+    }
+
     const newValue = body.showInStorefront ? 1 : 0;
     db.prepare('UPDATE stashes SET show_in_storefront = ? WHERE id = ?').run(newValue, id);
 

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -6,12 +6,315 @@ import type { AuthVariables } from '../middleware/auth.js';
 import type {
   CreateStashRequest,
   CreateStashResponse,
+  GeneratedPreviewPayload,
+  StashProof,
+  StashProofSecret,
   StashPublicInfo,
   APIResponse,
 } from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const stashRoutes = new Hono<{ Variables: AuthVariables }>();
+
+const HASH_RE = /^[0-9a-f]{64}$/;
+const BASE64URL_RE = /^[A-Za-z0-9_-]*$/;
+const MAX_PREVIEW_PAYLOAD_JSON_LENGTH = 64 * 1024;
+const MAX_PREVIEW_BASE64URL_LENGTH = 64 * 1024;
+const MAX_PREVIEW_CONTENT_BYTES = 16 * 1024;
+const MAX_PREVIEW_CHARS = 4_000;
+const MAX_MERKLE_PROOF_STEPS = 64;
+const MAX_TEXT_PREVIEW_RATIO = 0.5;
+const TEXT_LINE_LIMITS = new Set([4, 10, 20, 50]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.length <= maxLength;
+}
+
+function isPositiveInteger(value: unknown, max = Number.MAX_SAFE_INTEGER): value is number {
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= max;
+}
+
+function isHash(value: unknown): value is string {
+  return typeof value === 'string' && HASH_RE.test(value);
+}
+
+function base64UrlDecodedLength(value: string): number | null {
+  if (value.length % 4 === 1) return null;
+  if (value.length === 0) return 0;
+
+  const padding = value.length % 4 === 0 ? 0 : 4 - (value.length % 4);
+  return ((value.length + padding) / 4) * 3 - padding;
+}
+
+function decodeBase64Url(value: string): Uint8Array | null {
+  if (value.length % 4 === 1) return null;
+
+  try {
+    const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    return Buffer.from(padded, 'base64');
+  } catch {
+    return null;
+  }
+}
+
+function decodePreviewText(value: string): string | null {
+  const bytes = decodeBase64Url(value);
+  if (!bytes) return null;
+
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  return text.split(/\r\n|\r|\n/).length;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function isMerkleProofStep(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['side', 'hash']) &&
+    (value.side === 'left' || value.side === 'right') &&
+    isHash(value.hash)
+  );
+}
+
+function isPreviewInclusionProof(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['offset', 'length', 'leafHash', 'path']) &&
+    isPositiveInteger(value.offset, 100 * 1024 * 1024) &&
+    isPositiveInteger(value.length, MAX_PREVIEW_CONTENT_BYTES) &&
+    (value.length as number) > 0 &&
+    isHash(value.leafHash) &&
+    Array.isArray(value.path) &&
+    value.path.length <= MAX_MERKLE_PROOF_STEPS &&
+    value.path.every(isMerkleProofStep)
+  );
+}
+
+function isStashProof(value: unknown): value is StashProof {
+  if (!isRecord(value)) return false;
+
+  const keys = [
+    'version',
+    'root',
+    'previewHash',
+    'contentMerkleRoot',
+    'contentLength',
+    'chunkSize',
+    'previewInclusion',
+  ];
+
+  return (
+    hasOnlyKeys(value, keys) &&
+    value.version === 'stashu-preview-v1' &&
+    isHash(value.root) &&
+    isHash(value.previewHash) &&
+    isHash(value.contentMerkleRoot) &&
+    isPositiveInteger(value.contentLength, 100 * 1024 * 1024) &&
+    isPositiveInteger(value.chunkSize, 1024 * 1024) &&
+    (value.chunkSize as number) >= 1024 &&
+    (value.previewInclusion === undefined || isPreviewInclusionProof(value.previewInclusion))
+  );
+}
+
+function isPreviewSecret(value: unknown): value is StashProofSecret {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, ['contentSalt']) &&
+    typeof value.contentSalt === 'string' &&
+    HASH_RE.test(value.contentSalt)
+  );
+}
+
+function isTextPreviewPayload(
+  value: Record<string, unknown>,
+  options: Record<string, unknown>,
+  metadata: Record<string, unknown>
+): boolean {
+  const decodedPreviewLength =
+    typeof value.bytes === 'string' ? base64UrlDecodedLength(value.bytes) : null;
+  const decodedPreviewText =
+    typeof value.bytes === 'string' ? decodePreviewText(value.bytes) : null;
+  const decodedPreviewChars =
+    decodedPreviewText === null ? null : Array.from(decodedPreviewText).length;
+  const decodedPreviewLines = decodedPreviewText === null ? null : countLines(decodedPreviewText);
+
+  return (
+    value.kind === 'text-peek' &&
+    decodedPreviewLength !== null &&
+    decodedPreviewLength > 0 &&
+    decodedPreviewText !== null &&
+    decodedPreviewChars !== null &&
+    decodedPreviewLines !== null &&
+    hasOnlyKeys(options, ['mode', 'lineLimit', 'maxBytes', 'maxChars', 'maxPreviewRatio']) &&
+    (options.mode === 'auto' || options.mode === 'excerpt') &&
+    TEXT_LINE_LIMITS.has(options.lineLimit as number) &&
+    isPositiveInteger(options.maxBytes, MAX_PREVIEW_CONTENT_BYTES) &&
+    (options.maxBytes as number) > 0 &&
+    isPositiveInteger(options.maxChars, MAX_PREVIEW_CHARS) &&
+    (options.maxChars as number) > 0 &&
+    typeof options.maxPreviewRatio === 'number' &&
+    Number.isFinite(options.maxPreviewRatio) &&
+    options.maxPreviewRatio >= 0 &&
+    options.maxPreviewRatio <= MAX_TEXT_PREVIEW_RATIO &&
+    hasOnlyKeys(metadata, [
+      'offset',
+      'lineLimit',
+      'linesIncluded',
+      'bytesRead',
+      'previewBytes',
+      'truncated',
+    ]) &&
+    isPositiveInteger(metadata.offset, value.fileSize as number) &&
+    metadata.lineLimit === options.lineLimit &&
+    isPositiveInteger(metadata.linesIncluded, options.lineLimit as number) &&
+    isPositiveInteger(metadata.bytesRead, options.maxBytes as number) &&
+    isPositiveInteger(metadata.previewBytes, metadata.bytesRead as number) &&
+    (metadata.offset as number) + (metadata.previewBytes as number) <= (value.fileSize as number) &&
+    metadata.previewBytes <= Math.floor((value.fileSize as number) * options.maxPreviewRatio) &&
+    metadata.previewBytes === decodedPreviewLength &&
+    decodedPreviewChars <= (options.maxChars as number) &&
+    decodedPreviewLines <= (options.lineLimit as number) &&
+    metadata.linesIncluded === decodedPreviewLines &&
+    typeof metadata.truncated === 'boolean'
+  );
+}
+
+function isFileSummaryPayload(
+  value: Record<string, unknown>,
+  options: Record<string, unknown>,
+  metadata: Record<string, unknown>
+): boolean {
+  return (
+    value.kind === 'file-summary' &&
+    hasOnlyKeys(options, []) &&
+    hasOnlyKeys(metadata, ['reason']) &&
+    (metadata.reason === 'unsupported-type' ||
+      metadata.reason === 'decode-failed' ||
+      metadata.reason === 'preview-disabled' ||
+      metadata.reason === 'preview-would-reveal-file') &&
+    value.bytes === ''
+  );
+}
+
+function isGeneratedPreviewPayload(
+  value: unknown,
+  fileName: string,
+  fileSize: number
+): value is GeneratedPreviewPayload {
+  if (!isRecord(value) || !isRecord(value.options) || !isRecord(value.metadata)) return false;
+  if (
+    !hasOnlyKeys(value, [
+      'version',
+      'kind',
+      'fileName',
+      'fileType',
+      'fileSize',
+      'contentType',
+      'options',
+      'metadata',
+      'bytes',
+    ])
+  ) {
+    return false;
+  }
+
+  if (
+    value.version !== 'stashu-generated-preview-v1' ||
+    value.fileName !== fileName ||
+    value.fileSize !== fileSize ||
+    !isString(value.fileType, 200) ||
+    !isString(value.contentType, 100) ||
+    !isString(value.bytes, MAX_PREVIEW_BASE64URL_LENGTH) ||
+    !BASE64URL_RE.test(value.bytes)
+  ) {
+    return false;
+  }
+
+  if (value.kind === 'text-peek') {
+    return isTextPreviewPayload(value, value.options, value.metadata);
+  }
+
+  return isFileSummaryPayload(value, value.options, value.metadata);
+}
+
+function validatePreviewBundle(body: CreateStashRequest): string | null {
+  const fields = [body.generatedPreview, body.previewProof, body.previewSecret];
+  const provided = fields.filter((field) => field !== undefined && field !== null).length;
+
+  if (provided === 0) return null;
+  if (provided !== fields.length) {
+    return 'generatedPreview, previewProof, and previewSecret must be provided together';
+  }
+
+  if (!isGeneratedPreviewPayload(body.generatedPreview, body.fileName, body.fileSize)) {
+    return 'generatedPreview is invalid';
+  }
+
+  if (JSON.stringify(body.generatedPreview).length > MAX_PREVIEW_PAYLOAD_JSON_LENGTH) {
+    return 'generatedPreview is too large';
+  }
+
+  if (!isStashProof(body.previewProof)) {
+    return 'previewProof is invalid';
+  }
+
+  if (body.previewProof.contentLength !== body.fileSize) {
+    return 'previewProof content length must match fileSize';
+  }
+
+  if (body.generatedPreview.kind === 'text-peek') {
+    const { offset, previewBytes } = body.generatedPreview.metadata as {
+      offset: number;
+      previewBytes: number;
+    };
+    if (previewBytes > 0) {
+      if (!body.previewProof.previewInclusion) {
+        return 'previewProof must include text preview inclusion proof';
+      }
+      if (body.previewProof.previewInclusion.offset !== offset) {
+        return 'previewProof preview offset must match generatedPreview metadata';
+      }
+      if (body.previewProof.previewInclusion.length !== previewBytes) {
+        return 'previewProof preview length must match generatedPreview metadata';
+      }
+      if (offset + previewBytes > body.fileSize) {
+        return 'previewProof preview range must fit inside the file';
+      }
+    }
+  } else if (body.previewProof.previewInclusion) {
+    return 'file-summary previews must not include preview inclusion proof';
+  }
+
+  if (!isPreviewSecret(body.previewSecret)) {
+    return 'previewSecret is invalid';
+  }
+
+  return null;
+}
+
+function parseStoredJson<T>(value: string | null): T | undefined {
+  return value ? (JSON.parse(decrypt(value)) as T) : undefined;
+}
+
+function stringifyEncryptedJson(value: unknown): string {
+  return encrypt(JSON.stringify(value));
+}
 
 // POST /api/stash - Create a new stash (requires NIP-98 auth)
 stashRoutes.post('/', async (c) => {
@@ -62,23 +365,32 @@ stashRoutes.post('/', async (c) => {
       );
     }
 
-    if (body.blobSha256 && !/^[0-9a-f]{64}$/.test(body.blobSha256)) {
+    if (body.blobSha256 && !HASH_RE.test(body.blobSha256)) {
       return c.json<APIResponse<never>>(
         { success: false, error: 'blobSha256 must be 64 lowercase hex characters' },
         400
       );
     }
 
+    const previewError = validatePreviewBundle(body);
+    if (previewError) {
+      return c.json<APIResponse<never>>({ success: false, error: previewError }, 400);
+    }
+
     const id = uuidv4();
 
     const stmt = db.prepare(`
-      INSERT INTO stashes (id, blob_url, blob_sha256, secret_key, seller_pubkey, price_sats, title, description, file_name, file_size, preview_url)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO stashes (
+        id, blob_url, blob_sha256, secret_key, seller_pubkey, price_sats,
+        title, description, file_name, file_size, preview_url,
+        generated_preview_payload, preview_proof, preview_secret
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
       id,
-      body.blobUrl,
+      encrypt(body.blobUrl),
       body.blobSha256 || null,
       encrypt(body.secretKey),
       pubkey, // Use authed pubkey, not body.sellerPubkey (prevents spoofing)
@@ -87,7 +399,10 @@ stashRoutes.post('/', async (c) => {
       body.description ? encrypt(body.description) : null,
       encrypt(body.fileName),
       body.fileSize,
-      body.previewUrl || null
+      body.previewUrl || null,
+      body.generatedPreview ? stringifyEncryptedJson(body.generatedPreview) : null,
+      body.previewProof ? stringifyEncryptedJson(body.previewProof) : null,
+      body.previewSecret ? stringifyEncryptedJson(body.previewSecret) : null
     );
 
     const shareUrl = `/s/${id}`;
@@ -166,13 +481,22 @@ stashRoutes.get('/:id', async (c) => {
     const id = c.req.param('id');
 
     const stmt = db.prepare(`
-      SELECT id, title, description, file_name, file_size, price_sats, preview_url
+      SELECT id, title, description, file_name, file_size, price_sats, preview_url,
+             generated_preview_payload, preview_proof
       FROM stashes WHERE id = ?
     `);
 
     const stash = stmt.get(id) as Pick<
       StashRow,
-      'id' | 'title' | 'description' | 'file_name' | 'file_size' | 'price_sats' | 'preview_url'
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'file_name'
+      | 'file_size'
+      | 'price_sats'
+      | 'preview_url'
+      | 'generated_preview_payload'
+      | 'preview_proof'
     > | null;
 
     if (!stash) {
@@ -194,6 +518,8 @@ stashRoutes.get('/:id', async (c) => {
       fileSize: stash.file_size,
       priceSats: stash.price_sats,
       previewUrl: stash.preview_url ?? undefined,
+      generatedPreview: parseStoredJson<GeneratedPreviewPayload>(stash.generated_preview_payload),
+      previewProof: parseStoredJson<StashProof>(stash.preview_proof),
     };
 
     return c.json<APIResponse<StashPublicInfo>>({

--- a/server/src/routes/unlock.test.ts
+++ b/server/src/routes/unlock.test.ts
@@ -34,14 +34,19 @@ const TEST_STASH = {
   priceSats: 100,
 };
 
-function insertStash(id = TEST_STASH.id) {
+const PREVIEW_SECRET = { contentSalt: 'd'.repeat(64) };
+
+function insertStash(id = TEST_STASH.id, previewSecret?: typeof PREVIEW_SECRET) {
   db.prepare(
-    `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO stashes (
+       id, blob_url, secret_key, preview_secret, seller_pubkey, price_sats, title, file_name, file_size
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     id,
-    TEST_STASH.blobUrl,
+    encrypt(TEST_STASH.blobUrl),
     encrypt(TEST_STASH.secretKey),
+    previewSecret ? encrypt(JSON.stringify(previewSecret)) : null,
     'seller-pubkey',
     TEST_STASH.priceSats,
     encrypt('Test Stash'),
@@ -108,6 +113,20 @@ describe('POST /api/unlock/:id', () => {
     assert.equal(data.claimToken.length, 64, 'claimToken should be 64 hex chars');
   });
 
+  it('returns preview secret after an already-paid unlock', async () => {
+    insertStash(TEST_STASH.id, PREVIEW_SECRET);
+    insertPayment(TEST_STASH.id, 'cashuPaidToken', 'paid', 'cashuSellerToken');
+
+    const res = await app.request(`/api/unlock/${TEST_STASH.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'cashuPaidToken' }),
+    });
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+    assert.deepEqual(data.previewSecret, PREVIEW_SECRET);
+  });
+
   it('returns 409 for pending payment', async () => {
     insertStash();
     insertPayment(TEST_STASH.id, 'cashuPendingToken', 'pending');
@@ -151,7 +170,7 @@ describe('GET /api/unlock/:id/claim', () => {
   }
 
   it('returns unlock data for valid claim token', async () => {
-    insertStash();
+    insertStash(TEST_STASH.id, PREVIEW_SECRET);
     const claimToken = 'a'.repeat(64);
     const expiresAt = Math.floor(Date.now() / 1000) + 3600;
     insertPaidPaymentWithClaim(TEST_STASH.id, claimToken, expiresAt);
@@ -162,6 +181,7 @@ describe('GET /api/unlock/:id/claim', () => {
     assert.equal(data.secretKey, TEST_STASH.secretKey);
     assert.equal(data.blobUrl, TEST_STASH.blobUrl);
     assert.equal(data.fileName, TEST_STASH.fileName);
+    assert.deepEqual(data.previewSecret, PREVIEW_SECRET);
   });
 
   it('returns 400 when token query param is missing', async () => {

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -5,10 +5,19 @@ import { verifyAndSwapToken } from '../lib/cashu.js';
 import { encrypt, decrypt } from '../lib/encryption.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 import { rateLimit } from '../middleware/ratelimit.js';
-import type { UnlockRequest, UnlockResponse, APIResponse } from '../../../shared/types.js';
+import type {
+  StashProofSecret,
+  UnlockRequest,
+  UnlockResponse,
+  APIResponse,
+} from '../../../shared/types.js';
 import type { StashRow, PaymentRow } from '../db/types.js';
 
 export const unlockRoutes = new Hono();
+
+function decryptPreviewSecret(value: string | null): StashProofSecret | undefined {
+  return value ? (JSON.parse(decrypt(value)) as StashProofSecret) : undefined;
+}
 
 // POST /api/unlock/:id - Unlock a stash with Cashu token
 unlockRoutes.post('/:id', async (c) => {
@@ -28,7 +37,7 @@ unlockRoutes.post('/:id', async (c) => {
 
     // Get stash details
     const stashStmt = db.prepare(`
-      SELECT id, blob_url, blob_sha256, secret_key, file_name, price_sats, seller_pubkey
+      SELECT id, blob_url, blob_sha256, secret_key, preview_secret, file_name, price_sats, seller_pubkey
       FROM stashes WHERE id = ?
     `);
     const stash = stashStmt.get(stashId) as Pick<
@@ -37,6 +46,7 @@ unlockRoutes.post('/:id', async (c) => {
       | 'blob_url'
       | 'blob_sha256'
       | 'secret_key'
+      | 'preview_secret'
       | 'file_name'
       | 'price_sats'
       | 'seller_pubkey'
@@ -84,9 +94,10 @@ unlockRoutes.post('/:id', async (c) => {
           success: true,
           data: {
             secretKey: decrypt(stash.secret_key),
-            blobUrl: stash.blob_url,
+            blobUrl: decrypt(stash.blob_url),
             blobSha256: stash.blob_sha256 ?? undefined,
             fileName: decrypt(stash.file_name),
+            previewSecret: decryptPreviewSecret(stash.preview_secret),
             claimToken,
           },
         });
@@ -162,9 +173,10 @@ unlockRoutes.post('/:id', async (c) => {
       success: true,
       data: {
         secretKey: decrypt(stash.secret_key),
-        blobUrl: stash.blob_url,
+        blobUrl: decrypt(stash.blob_url),
         blobSha256: stash.blob_sha256 ?? undefined,
         fileName: decrypt(stash.file_name),
+        previewSecret: decryptPreviewSecret(stash.preview_secret),
         claimToken,
       },
     });
@@ -207,8 +219,13 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
   }
 
   const stash = db
-    .prepare('SELECT secret_key, blob_url, blob_sha256, file_name FROM stashes WHERE id = ?')
-    .get(stashId) as Pick<StashRow, 'secret_key' | 'blob_url' | 'blob_sha256' | 'file_name'> | null;
+    .prepare(
+      'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name FROM stashes WHERE id = ?'
+    )
+    .get(stashId) as Pick<
+    StashRow,
+    'secret_key' | 'blob_url' | 'blob_sha256' | 'preview_secret' | 'file_name'
+  > | null;
 
   if (!stash) {
     return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
@@ -218,9 +235,10 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
     success: true,
     data: {
       secretKey: decrypt(stash.secret_key),
-      blobUrl: stash.blob_url,
+      blobUrl: decrypt(stash.blob_url),
       blobSha256: stash.blob_sha256 ?? undefined,
       fileName: decrypt(stash.file_name),
+      previewSecret: decryptPreviewSecret(stash.preview_secret),
     },
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -9,6 +9,69 @@ export type APIResponse<T> = { success: true; data: T } | { success: false; erro
 // Stash Types
 // ============================================
 
+export type GeneratedPreviewKind = 'text-peek' | 'file-summary';
+
+export interface TextPreviewOptions {
+  mode: 'auto' | 'excerpt';
+  lineLimit: 4 | 10 | 20 | 50;
+  maxBytes: number;
+  maxChars: number;
+  maxPreviewRatio: number;
+}
+
+export type FileSummaryOptions = Record<string, never>;
+
+export interface TextPreviewMetadata {
+  offset: number;
+  lineLimit: 4 | 10 | 20 | 50;
+  linesIncluded: number;
+  bytesRead: number;
+  previewBytes: number;
+  truncated: boolean;
+}
+
+export interface FileSummaryMetadata {
+  reason: 'unsupported-type' | 'decode-failed' | 'preview-disabled' | 'preview-would-reveal-file';
+}
+
+export interface GeneratedPreviewPayload {
+  version: 'stashu-generated-preview-v1';
+  kind: GeneratedPreviewKind;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+  contentType: string;
+  options: TextPreviewOptions | FileSummaryOptions;
+  metadata: TextPreviewMetadata | FileSummaryMetadata;
+  bytes: string;
+}
+
+export interface StashProof {
+  version: 'stashu-preview-v1';
+  root: string;
+  previewHash: string;
+  contentMerkleRoot: string;
+  contentLength: number;
+  chunkSize: number;
+  previewInclusion?: PreviewInclusionProof;
+}
+
+export interface MerkleProofStep {
+  side: 'left' | 'right';
+  hash: string;
+}
+
+export interface PreviewInclusionProof {
+  offset: number;
+  length: number;
+  leafHash: string;
+  path: MerkleProofStep[];
+}
+
+export interface StashProofSecret {
+  contentSalt: string;
+}
+
 export interface Stash {
   id: string;
   blobUrl: string;
@@ -21,6 +84,9 @@ export interface Stash {
   fileName: string;
   fileSize: number;
   previewUrl?: string;
+  generatedPreview?: GeneratedPreviewPayload;
+  previewProof?: StashProof;
+  previewSecret?: StashProofSecret;
   createdAt: number;
 }
 
@@ -33,6 +99,8 @@ export interface StashPublicInfo {
   fileSize: number;
   priceSats: number;
   previewUrl?: string;
+  generatedPreview?: GeneratedPreviewPayload;
+  previewProof?: StashProof;
 }
 
 // ============================================
@@ -67,6 +135,9 @@ export interface CreateStashRequest {
   fileName: string;
   fileSize: number;
   previewUrl?: string;
+  generatedPreview?: GeneratedPreviewPayload;
+  previewProof?: StashProof;
+  previewSecret?: StashProofSecret;
 }
 
 export interface CreateStashResponse {
@@ -85,6 +156,7 @@ export interface UnlockResponse {
   blobSha256?: string;
   fileName: string;
   claimToken?: string;
+  previewSecret?: StashProofSecret;
 }
 
 // GET /api/earnings (for seller dashboard)
@@ -151,6 +223,7 @@ export interface PayStatusResponse {
   blobSha256?: string;
   fileName?: string;
   claimToken?: string;
+  previewSecret?: StashProofSecret;
 }
 
 // POST /api/withdraw/resolve-address


### PR DESCRIPTION
Closes #46

This adds the first version of Verified Peek.

The main idea is: if a seller shows a preview, it should come from the file itself and be tied to the same file the buyer unlocks later.

What changed:
- added generated previews for text-like files
- added no preview / quick preview / choose text options while creating a stash
- quick preview uses the start of the file
- choose text lets the seller pick start, middle, end, or a custom selected excerpt
- added preview limits so sellers do not accidentally reveal too much
- added a proof bundle that ties the public preview to the committed file
- added a Merkle-style content commitment so the unlocked file can be checked later
- stored preview proof data on the server, with proof fields encrypted at rest
- return the proof secret only after unlock/payment
- show Verified Peek on the buyer page before payment
- block payment if the published preview/proof does not verify
- verify the decrypted file before showing the download as verified
- show verification details after unlock, including proof root and blob hash
- keep non-text files supported with a no-public-preview commitment check for now
- added tests around preview generation, proof verification, server validation, unlock, and tamper cases
- added a little UI polish around preview controls and page transitions
- cleaned up primary action buttons and toast styling so the new flow feels more consistent across the app
- tightened storefront visibility so stashes cannot be marked public unless the seller storefront is enabled first

