### PR TITLE
fix: polish verified peek fallback ui

### DIFF
--- a/client/src/components/FileUploader.tsx
+++ b/client/src/components/FileUploader.tsx
@@ -14,6 +14,7 @@ import {
 
 interface FileUploaderProps {
   onFileSelect: (file: File) => void;
+  onFileClear?: () => void;
   disabled?: boolean;
   maxSizeMB?: number;
 }
@@ -43,6 +44,7 @@ function formatSize(bytes: number): string {
 
 export function FileUploader({
   onFileSelect,
+  onFileClear,
   disabled = false,
   maxSizeMB = 50,
 }: FileUploaderProps) {
@@ -88,6 +90,7 @@ export function FileUploader({
   const clearFile = () => {
     setSelectedFile(null);
     setError(null);
+    onFileClear?.();
   };
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -125,6 +128,7 @@ export function FileUploader({
       <div className="w-full">
         <div className="bg-slate-800/50 border border-slate-700 rounded-2xl p-5 relative group">
           <button
+            type="button"
             onClick={clearFile}
             className="absolute top-3 right-3 p-1.5 rounded-lg bg-slate-700/50 hover:bg-slate-600 text-slate-400 hover:text-white transition-colors opacity-0 group-hover:opacity-100"
             title="Remove file"

--- a/client/src/components/SellPage.tsx
+++ b/client/src/components/SellPage.tsx
@@ -15,6 +15,7 @@ import {
   MAX_TEXT_PREVIEW_CHARS,
   generatePreviewFromBytes,
   generatePreviewFromFile,
+  isTextPreviewSupported,
   type GeneratedPreviewPayload,
   type TextLineLimit,
 } from '../lib/generatedPreview';
@@ -233,8 +234,7 @@ export function SellPage() {
     return !hasAcknowledgedRecovery();
   });
 
-  const handleFileSelect = (file: File) => {
-    setSelectedFile(file);
+  const resetPreviewState = () => {
     setGeneratedPreview(null);
     setPreviewError(null);
     setFileText(null);
@@ -245,7 +245,21 @@ export function SellPage() {
     setShowPreviewControls(false);
   };
 
+  const handleFileSelect = (file: File) => {
+    setSelectedFile(file);
+    resetPreviewState();
+  };
+
+  const handleFileClear = () => {
+    setSelectedFile(null);
+    resetPreviewState();
+  };
+
   const activePreviewPreset = PREVIEW_PRESETS[previewPreset];
+  const textPreviewSupported = useMemo(
+    () => (selectedFile ? isTextPreviewSupported(selectedFile.name, selectedFile.type) : false),
+    [selectedFile]
+  );
 
   useEffect(() => {
     if (!selectedFile) return;
@@ -639,7 +653,11 @@ export function SellPage() {
 
         {/* File Upload */}
         <div className="mb-8">
-          <FileUploader onFileSelect={handleFileSelect} disabled={stash.status !== 'idle'} />
+          <FileUploader
+            onFileSelect={handleFileSelect}
+            onFileClear={handleFileClear}
+            disabled={stash.status !== 'idle'}
+          />
         </div>
 
         {selectedFile && (
@@ -650,243 +668,263 @@ export function SellPage() {
                 <h2 className="text-white font-semibold">Preview for buyers</h2>
               </div>
               <p className="mt-1 text-sm text-slate-400">
-                Choose whether buyers can see a verified sample before paying.
+                {textPreviewSupported
+                  ? 'Choose whether buyers can see a verified sample before paying.'
+                  : 'Text previews are not available for this file type yet.'}
               </p>
             </div>
 
-            <div className="mb-4 grid gap-2 sm:grid-cols-3">
-              {[
-                {
-                  label: 'No preview',
-                  body: 'Most private',
-                  value: 'none' as const,
-                },
-                {
-                  label: 'Quick preview',
-                  body: 'Start of file',
-                  value: 'auto' as const,
-                },
-                {
-                  label: 'Choose text',
-                  body: 'You pick it',
-                  value: 'excerpt' as const,
-                },
-              ].map((option) => (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() => {
-                    if (option.value === peekMode) return;
+            {!textPreviewSupported ? (
+              <div className="soft-appear flex items-start gap-3 rounded-xl border border-slate-700 bg-slate-950/50 p-4">
+                <FileText className="mt-0.5 h-5 w-5 shrink-0 text-slate-400" />
+                <div>
+                  <p className="text-sm text-slate-300">No public preview will be shown.</p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    Stashu will verify the unlocked file after payment.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <>
+                <div className="mb-4 grid gap-2 sm:grid-cols-3">
+                  {[
+                    {
+                      label: 'No preview',
+                      body: 'Most private',
+                      value: 'none' as const,
+                    },
+                    {
+                      label: 'Quick preview',
+                      body: 'Start of file',
+                      value: 'auto' as const,
+                    },
+                    {
+                      label: 'Choose text',
+                      body: 'You pick it',
+                      value: 'excerpt' as const,
+                    },
+                  ].map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => {
+                        if (option.value === peekMode) return;
 
-                    setPeekMode(option.value);
-                    setGeneratedPreview(null);
-                    setPreviewError(null);
-                    if (option.value !== 'excerpt') {
-                      setFileText(null);
-                      setQuickExcerptPosition(null);
-                      setSelectedExcerpt(null);
-                    }
-                  }}
-                  className={`rounded-xl border px-3 py-3 text-left transition-colors ${
-                    peekMode === option.value
-                      ? 'border-orange-500 bg-orange-500/10 text-white'
-                      : 'border-slate-700 bg-slate-900/40 text-slate-400 hover:border-slate-500 hover:text-white'
+                        setPeekMode(option.value);
+                        setGeneratedPreview(null);
+                        setPreviewError(null);
+                        if (option.value !== 'excerpt') {
+                          setFileText(null);
+                          setQuickExcerptPosition(null);
+                          setSelectedExcerpt(null);
+                        }
+                      }}
+                      className={`rounded-xl border px-3 py-3 text-left transition-colors ${
+                        peekMode === option.value
+                          ? 'border-orange-500 bg-orange-500/10 text-white'
+                          : 'border-slate-700 bg-slate-900/40 text-slate-400 hover:border-slate-500 hover:text-white'
+                      }`}
+                    >
+                      <span className="block text-sm font-semibold">{option.label}</span>
+                      <span className="mt-1 block text-xs opacity-75">{option.body}</span>
+                    </button>
+                  ))}
+                </div>
+
+                <div
+                  className={`soft-surface mb-4 rounded-xl border p-3 ${
+                    peekModeInfo.tone === 'public'
+                      ? 'border-amber-500/30 bg-amber-500/10'
+                      : 'border-slate-700 bg-slate-950/50'
                   }`}
                 >
-                  <span className="block text-sm font-semibold">{option.label}</span>
-                  <span className="mt-1 block text-xs opacity-75">{option.body}</span>
-                </button>
-              ))}
-            </div>
-
-            <div
-              className={`soft-surface mb-4 rounded-xl border p-3 ${
-                peekModeInfo.tone === 'public'
-                  ? 'border-amber-500/30 bg-amber-500/10'
-                  : 'border-slate-700 bg-slate-950/50'
-              }`}
-            >
-              <p
-                className={`text-sm font-medium ${
-                  peekModeInfo.tone === 'public' ? 'text-amber-200' : 'text-slate-200'
-                }`}
-              >
-                {peekModeInfo.title}
-              </p>
-              <p
-                className={`mt-1 text-xs ${
-                  peekModeInfo.tone === 'public' ? 'text-amber-100/70' : 'text-slate-500'
-                }`}
-              >
-                {peekModeInfo.body}
-              </p>
-            </div>
-
-            <div>
-              {peekMode !== 'none' && (
-                <div className="mb-4">
-                  <button
-                    type="button"
-                    onClick={() => setShowPreviewControls((value) => !value)}
-                    className="inline-flex items-center gap-2 text-sm font-medium text-slate-400 transition-colors hover:text-white"
+                  <p
+                    className={`text-sm font-medium ${
+                      peekModeInfo.tone === 'public' ? 'text-amber-200' : 'text-slate-200'
+                    }`}
                   >
-                    <SlidersHorizontal className="h-4 w-4" />
-                    More control
-                  </button>
-
-                  {showPreviewControls && (
-                    <div className="soft-appear mt-3 rounded-xl border border-slate-700 bg-slate-950/40 p-3">
-                      <div className="grid gap-2 sm:grid-cols-3">
-                        {(Object.keys(PREVIEW_PRESETS) as PreviewPresetId[]).map((presetId) => {
-                          const preset = PREVIEW_PRESETS[presetId];
-                          return (
-                            <button
-                              key={presetId}
-                              type="button"
-                              onClick={() => {
-                                if (presetId === previewPreset) return;
-
-                                setPreviewPreset(presetId);
-                                setPreviewError(null);
-                              }}
-                              className={`rounded-lg border px-3 py-2 text-left transition-colors ${
-                                previewPreset === presetId
-                                  ? 'border-orange-500 bg-orange-500/10 text-white'
-                                  : 'border-slate-700 text-slate-400 hover:border-slate-500 hover:text-white'
-                              }`}
-                            >
-                              <span className="block text-sm font-semibold">{preset.label}</span>
-                              <span className="mt-1 block text-xs opacity-75">{preset.body}</span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                      <p className="mt-3 text-xs text-slate-500">
-                        {activePreviewPreset.label}: up to {activePreviewPreset.lineLimit} lines,{' '}
-                        {activePreviewPreset.maxChars.toLocaleString()} chars, or{' '}
-                        {formatPercent(activePreviewPreset.maxPreviewRatio * 100)} of this file.
-                        Safety cap: {formatBytes(DEFAULT_TEXT_MAX_BYTES)}.
-                      </p>
-                    </div>
-                  )}
+                    {peekModeInfo.title}
+                  </p>
+                  <p
+                    className={`mt-1 text-xs ${
+                      peekModeInfo.tone === 'public' ? 'text-amber-100/70' : 'text-slate-500'
+                    }`}
+                  >
+                    {peekModeInfo.body}
+                  </p>
                 </div>
-              )}
 
-              {peekMode === 'excerpt' && fileText !== null && (
-                <div className="soft-appear">
-                  <p className="mb-2 text-xs text-slate-500">
-                    Pick a quick sample, or select text below. The public preview updates when you
-                    finish selecting.
-                  </p>
-                  <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
-                    Quick sample
-                  </p>
-                  <div className="mb-2 flex flex-wrap items-center gap-2">
-                    {[
-                      { label: 'Start', value: 'start' as const },
-                      { label: 'Middle', value: 'middle' as const },
-                      { label: 'End', value: 'end' as const },
-                    ].map((option) => (
+                <div>
+                  {peekMode !== 'none' && (
+                    <div className="mb-4">
                       <button
-                        key={option.value}
                         type="button"
-                        onClick={() => applyQuickExcerpt(option.value)}
-                        className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
-                          quickExcerptPosition === option.value
-                            ? 'border-orange-500 bg-orange-500/10 text-white'
-                            : 'border-slate-700 text-slate-300 hover:border-slate-500 hover:text-white'
-                        }`}
+                        onClick={() => setShowPreviewControls((value) => !value)}
+                        className="inline-flex items-center gap-2 text-sm font-medium text-slate-400 transition-colors hover:text-white"
                       >
-                        {option.label}
+                        <SlidersHorizontal className="h-4 w-4" />
+                        More control
                       </button>
-                    ))}
-                  </div>
-                  <textarea
-                    value={fileText}
-                    onMouseUp={handleExcerptSelectionCommit}
-                    onKeyUp={handleExcerptSelectionCommit}
-                    onTouchEnd={handleExcerptSelectionCommit}
-                    readOnly
-                    rows={8}
-                    className="mb-4 w-full resize-none rounded-xl border border-slate-700 bg-slate-950/70 p-4 text-sm text-slate-200 selection:bg-orange-500/30 selection:text-orange-50 focus:border-orange-500 focus:outline-none"
-                    spellCheck={false}
-                  />
-                  {selectedExcerptStats?.tooLarge && (
-                    <p className="soft-appear mb-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-xs text-rose-200">
-                      {selectedExcerptTooLargeMessage}
-                    </p>
+
+                      {showPreviewControls && (
+                        <div className="soft-appear mt-3 rounded-xl border border-slate-700 bg-slate-950/40 p-3">
+                          <div className="grid gap-2 sm:grid-cols-3">
+                            {(Object.keys(PREVIEW_PRESETS) as PreviewPresetId[]).map((presetId) => {
+                              const preset = PREVIEW_PRESETS[presetId];
+                              return (
+                                <button
+                                  key={presetId}
+                                  type="button"
+                                  onClick={() => {
+                                    if (presetId === previewPreset) return;
+
+                                    setPreviewPreset(presetId);
+                                    setPreviewError(null);
+                                  }}
+                                  className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                                    previewPreset === presetId
+                                      ? 'border-orange-500 bg-orange-500/10 text-white'
+                                      : 'border-slate-700 text-slate-400 hover:border-slate-500 hover:text-white'
+                                  }`}
+                                >
+                                  <span className="block text-sm font-semibold">
+                                    {preset.label}
+                                  </span>
+                                  <span className="mt-1 block text-xs opacity-75">
+                                    {preset.body}
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                          <p className="mt-3 text-xs text-slate-500">
+                            {activePreviewPreset.label}: up to {activePreviewPreset.lineLimit}{' '}
+                            lines, {activePreviewPreset.maxChars.toLocaleString()} chars, or{' '}
+                            {formatPercent(activePreviewPreset.maxPreviewRatio * 100)} of this file.
+                            Safety cap: {formatBytes(DEFAULT_TEXT_MAX_BYTES)}.
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {peekMode === 'excerpt' && fileText !== null && (
+                    <div className="soft-appear">
+                      <p className="mb-2 text-xs text-slate-500">
+                        Pick a quick sample, or select text below. The public preview updates when
+                        you finish selecting.
+                      </p>
+                      <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+                        Quick sample
+                      </p>
+                      <div className="mb-2 flex flex-wrap items-center gap-2">
+                        {[
+                          { label: 'Start', value: 'start' as const },
+                          { label: 'Middle', value: 'middle' as const },
+                          { label: 'End', value: 'end' as const },
+                        ].map((option) => (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => applyQuickExcerpt(option.value)}
+                            className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+                              quickExcerptPosition === option.value
+                                ? 'border-orange-500 bg-orange-500/10 text-white'
+                                : 'border-slate-700 text-slate-300 hover:border-slate-500 hover:text-white'
+                            }`}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                      <textarea
+                        value={fileText}
+                        onMouseUp={handleExcerptSelectionCommit}
+                        onKeyUp={handleExcerptSelectionCommit}
+                        onTouchEnd={handleExcerptSelectionCommit}
+                        readOnly
+                        rows={8}
+                        className="mb-4 w-full resize-none rounded-xl border border-slate-700 bg-slate-950/70 p-4 text-sm text-slate-200 selection:bg-orange-500/30 selection:text-orange-50 focus:border-orange-500 focus:outline-none"
+                        spellCheck={false}
+                      />
+                      {selectedExcerptStats?.tooLarge && (
+                        <p className="soft-appear mb-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-xs text-rose-200">
+                          {selectedExcerptTooLargeMessage}
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {previewError ? (
+                    <p className="text-red-400 text-sm">{previewError}</p>
+                  ) : displayPreviewText !== undefined ? (
+                    <>
+                      <div className="soft-appear rounded-lg border border-orange-500/25 bg-orange-500/10 p-3">
+                        <div className="mb-3">
+                          <p className="text-xs font-medium uppercase tracking-wide text-orange-200/80">
+                            {previewCardTitle}
+                          </p>
+                          <p className="mt-1 text-xs text-orange-50/60">{previewCardHint}</p>
+                        </div>
+                        <pre className="h-48 overflow-auto whitespace-pre-wrap break-words text-sm leading-relaxed text-orange-50/90">
+                          {displayPreviewText || 'Empty preview'}
+                        </pre>
+                      </div>
+                      <div className="pt-3">
+                        {displayPreviewStats ? (
+                          <p className="grid grid-cols-[4rem_5.5rem_6rem] gap-2 text-xs text-slate-500">
+                            <span className="tabular-nums">
+                              {displayPreviewStats.lines} line
+                              {displayPreviewStats.lines === 1 ? '' : 's'}
+                            </span>
+                            <span className="tabular-nums">
+                              {compactCount(displayPreviewStats.chars)} chars
+                            </span>
+                            <span className="tabular-nums">
+                              {formatPercent(displayPreviewStats.percent)} public
+                            </span>
+                          </p>
+                        ) : null}
+                        {largeReveal && (
+                          <p className="soft-appear mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-100">
+                            This is a larger public peek. Anyone with the stash link can read it
+                            before paying.
+                          </p>
+                        )}
+                      </div>
+                    </>
+                  ) : peekMode === 'auto' && fileSummaryText ? (
+                    <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                      <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                      <div>
+                        <p className="text-slate-300 text-sm">{fileSummaryText.title}</p>
+                        <p className="text-slate-500 text-xs mt-1">{fileSummaryText.body}</p>
+                      </div>
+                    </div>
+                  ) : peekMode === 'auto' ? null : peekMode === 'excerpt' ? (
+                    <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                      <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                      <div>
+                        <p className="text-slate-300 text-sm">Pick text to show buyers.</p>
+                        <p className="text-slate-500 text-xs mt-1">
+                          Use Start, Middle, End, or select text yourself.
+                        </p>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
+                      <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
+                      <div>
+                        <p className="text-slate-300 text-sm">No public preview will be shown.</p>
+                        <p className="text-slate-500 text-xs mt-1">
+                          The file will still get a commitment check after unlock.
+                        </p>
+                      </div>
+                    </div>
                   )}
                 </div>
-              )}
-
-              {previewError ? (
-                <p className="text-red-400 text-sm">{previewError}</p>
-              ) : displayPreviewText !== undefined ? (
-                <>
-                  <div className="soft-appear rounded-lg border border-orange-500/25 bg-orange-500/10 p-3">
-                    <div className="mb-3">
-                      <p className="text-xs font-medium uppercase tracking-wide text-orange-200/80">
-                        {previewCardTitle}
-                      </p>
-                      <p className="mt-1 text-xs text-orange-50/60">{previewCardHint}</p>
-                    </div>
-                    <pre className="h-48 overflow-auto whitespace-pre-wrap break-words text-sm leading-relaxed text-orange-50/90">
-                      {displayPreviewText || 'Empty preview'}
-                    </pre>
-                  </div>
-                  <div className="pt-3">
-                    {displayPreviewStats ? (
-                      <p className="grid grid-cols-[4rem_5.5rem_6rem] gap-2 text-xs text-slate-500">
-                        <span className="tabular-nums">
-                          {displayPreviewStats.lines} line
-                          {displayPreviewStats.lines === 1 ? '' : 's'}
-                        </span>
-                        <span className="tabular-nums">
-                          {compactCount(displayPreviewStats.chars)} chars
-                        </span>
-                        <span className="tabular-nums">
-                          {formatPercent(displayPreviewStats.percent)} public
-                        </span>
-                      </p>
-                    ) : null}
-                    {largeReveal && (
-                      <p className="soft-appear mt-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-100">
-                        This is a larger public peek. Anyone with the stash link can read it before
-                        paying.
-                      </p>
-                    )}
-                  </div>
-                </>
-              ) : peekMode === 'auto' && fileSummaryText ? (
-                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
-                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
-                  <div>
-                    <p className="text-slate-300 text-sm">{fileSummaryText.title}</p>
-                    <p className="text-slate-500 text-xs mt-1">{fileSummaryText.body}</p>
-                  </div>
-                </div>
-              ) : peekMode === 'auto' ? null : peekMode === 'excerpt' ? (
-                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
-                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
-                  <div>
-                    <p className="text-slate-300 text-sm">Pick text to show buyers.</p>
-                    <p className="text-slate-500 text-xs mt-1">
-                      Use Start, Middle, End, or select text yourself.
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <div className="soft-appear flex items-start gap-3 rounded-xl bg-slate-950/50 p-4">
-                  <FileText className="mt-0.5 w-5 h-5 shrink-0 text-slate-400" />
-                  <div>
-                    <p className="text-slate-300 text-sm">No public peek will be shown.</p>
-                    <p className="text-slate-500 text-xs mt-1">
-                      The file will still get a commitment check after unlock.
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
+              </>
+            )}
           </div>
         )}
 

--- a/client/src/components/SettingsPage.tsx
+++ b/client/src/components/SettingsPage.tsx
@@ -280,8 +280,8 @@ export function SettingsPage() {
                     />
                     <p className="text-slate-500 text-xs mt-1.5 flex items-start gap-1">
                       <Lightbulb className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500/60" />
-                      Use an always-online wallet (e.g. Alby, WoS, Coinos) for reliable
-                      auto-settlement. Self-custodial mobile wallets may miss payments when offline.
+                      Use a Lightning address you control. Auto-settlement works best when that
+                      address can receive reliably in the background.
                     </p>
                   </div>
 

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -499,7 +499,9 @@ export function UnlockPage() {
                 >
                   {previewVerification.state === 'invalid'
                     ? 'Stash verification failed'
-                    : 'Verified Peek'}
+                    : previewVerification.text !== undefined
+                      ? 'Verified Peek'
+                      : 'File verification ready'}
                 </p>
               </div>
 
@@ -524,8 +526,7 @@ export function UnlockPage() {
                 <div className="flex items-start gap-2 rounded-lg bg-slate-950/50 p-3 text-left">
                   <FileText className="mt-0.5 w-4 h-4 shrink-0 text-slate-400" />
                   <p className="text-sm text-slate-400">
-                    No public peek. Stashu will still check the unlocked file against this
-                    commitment after payment.
+                    No public preview. Stashu will verify the unlocked file after payment.
                   </p>
                 </div>
               )}
@@ -536,8 +537,9 @@ export function UnlockPage() {
         {!previewProofInvalid && (
           <>
             {/* Payment Tabs */}
-            <div className="flex mb-6 bg-slate-800/50 rounded-xl p-1">
+            <div className="flex mb-2 bg-slate-800/50 rounded-xl p-1">
               <button
+                type="button"
                 onClick={() => setTab('lightning')}
                 className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
                   tab === 'lightning'
@@ -546,9 +548,10 @@ export function UnlockPage() {
                 }`}
               >
                 <Zap className="w-4 h-4" />
-                Pay with Lightning
+                Lightning invoice
               </button>
               <button
+                type="button"
                 onClick={() => setTab('cashu')}
                 className={`flex-1 flex items-center justify-center gap-2 py-3 rounded-lg font-semibold transition-all text-sm ${
                   tab === 'cashu'
@@ -557,9 +560,12 @@ export function UnlockPage() {
                 }`}
               >
                 <Key className="w-4 h-4" />
-                Pay with Cashu
+                Cashu token
               </button>
             </div>
+            <p className="mb-6 text-center text-xs text-slate-500">
+              Pay an invoice, or paste a Cashu token directly.
+            </p>
 
             {/* Lightning Tab */}
             {tab === 'lightning' && (

--- a/client/src/lib/generatedPreview.test.ts
+++ b/client/src/lib/generatedPreview.test.ts
@@ -4,6 +4,7 @@ import {
   decodeGeneratedPreviewBytes,
   generatePreviewFromBytes,
   generatePreviewFromFile,
+  isTextPreviewSupported,
   serializeGeneratedPreviewPayload,
   type GeneratedPreviewPayload,
   type TextLineLimit,
@@ -391,6 +392,15 @@ describe('generated preview payloads', () => {
       expect(preview.metadata).toEqual({ reason: 'unsupported-type' });
       expect(preview.bytes).toBe('');
     }
+  });
+
+  it('exposes the same text support check for the upload UI', () => {
+    expect(isTextPreviewSupported('guide.md', 'application/octet-stream')).toBe(true);
+    expect(isTextPreviewSupported('notes.txt', '')).toBe(true);
+    expect(isTextPreviewSupported('data.json', 'application/json')).toBe(true);
+    expect(isTextPreviewSupported('paper.pdf', 'application/pdf')).toBe(false);
+    expect(isTextPreviewSupported('photo.png', 'image/png')).toBe(false);
+    expect(isTextPreviewSupported('bundle.zip', 'application/zip')).toBe(false);
   });
 
   it('falls back to a file summary when text decoding fails', () => {

--- a/client/src/lib/generatedPreview.ts
+++ b/client/src/lib/generatedPreview.ts
@@ -144,6 +144,10 @@ function isTextLike(fileName: string, fileType: string): boolean {
   );
 }
 
+export function isTextPreviewSupported(fileName: string, fileType?: string): boolean {
+  return isTextLike(fileName, normalizeFileType(fileType));
+}
+
 function normalizeLineLimit(lineLimit?: TextLineLimit): TextLineLimit {
   if (lineLimit === undefined) return DEFAULT_TEXT_LINE_LIMIT;
   if (TEXT_LINE_LIMITS.includes(lineLimit)) return lineLimit;


### PR DESCRIPTION
Small follow-up for Verified Peek.

Text preview controls now only show for file types Stashu can actually preview as text. For PDFs/images/archives/etc, the create page shows a no-public-preview state instead, while still keeping the post-unlock file verification.

Also fixed the remove-file flow so clearing an uploaded file clears the preview state too.

Tiny copy cleanup:
- non-preview buyer card now says “File verification ready”
- payment tabs now say “Lightning invoice” / “Cashu token”
- removed wallet-name suggestions from auto-settlement settings