### PR TITLE
add configurable per-stash re-download window

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ account is required.
 5. **Buyer pays** - either by paying a Lightning invoice or pasting a Cashu ecash
    token.
 6. **Browser unlocks the file** - after payment, the server returns the decryption
-   material, and the buyer browser decrypts and verifies the download locally.
+   material, and the buyer browser decrypts and verifies the download locally. The
+   buyer can re-download on the same device until the seller's re-download window
+   ends.
 
 ## Verified Peek
 
@@ -117,14 +119,15 @@ after a valid unlock.
 
 ### Known Limits
 
-| Limit                  | Details                                                                                                                                             |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Trusted server         | The server currently stores encrypted file keys and decides when to release them after payment.                                                     |
-| Server compromise      | `TOKEN_ENCRYPTION_KEY` is co-located with the database. A root compromise can decrypt encrypted database fields.                                    |
-| Payment custody        | Seller Cashu tokens are held by the server until withdrawal or auto-settlement.                                                                     |
-| Browser key storage    | The seller Nostr private key lives in browser local storage.                                                                                        |
-| Preview privacy        | Verified Peek reveals the selected preview before payment. Stashu uses conservative defaults and limits, but the seller still chooses what to show. |
-| Single mint dependency | The server currently uses one configured Cashu mint through `MINT_URL`.                                                                             |
+| Limit                  | Details                                                                                                                                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trusted server         | The server currently stores encrypted file keys and decides when to release them after payment.                                                                                                                       |
+| Server compromise      | `TOKEN_ENCRYPTION_KEY` is co-located with the database. A root compromise can decrypt encrypted database fields.                                                                                                      |
+| Payment custody        | Seller Cashu tokens are held by the server until withdrawal or auto-settlement.                                                                                                                                       |
+| Browser key storage    | The seller Nostr private key lives in browser local storage.                                                                                                                                                          |
+| Preview privacy        | Verified Peek reveals the selected preview before payment. Stashu uses conservative defaults and limits, but the seller still chooses what to show.                                                                   |
+| Single mint dependency | The server currently uses one configured Cashu mint through `MINT_URL`.                                                                                                                                               |
+| Re-download window     | Buyers re-download with a per-device claim token in browser local storage that expires after the seller's window (1-30 days, default 7). It is not a shareable link, so clearing the browser ends re-download access. |
 
 ## Quick Start
 

--- a/client/src/components/SellPage.tsx
+++ b/client/src/components/SellPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '../lib/generatedPreview';
 import { decodeTextPreview } from '../lib/verifiedPreview';
 import type { TextPreviewMetadata } from '../../../shared/types';
+import { DOWNLOAD_WINDOW_OPTIONS, DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types';
 
 type PeekMode = 'none' | 'auto' | 'excerpt';
 type PreviewPresetId = 'shorter' | 'standard' | 'larger';
@@ -229,6 +230,9 @@ export function SellPage() {
   const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
   const [priceError, setPriceError] = useState<string | null>(null);
+  const [downloadWindowSeconds, setDownloadWindowSeconds] = useState<number>(
+    DEFAULT_DOWNLOAD_WINDOW_SECONDS
+  );
   const [showRecoveryModal, setShowRecoveryModal] = useState(() => {
     getOrCreateIdentity();
     return !hasAcknowledgedRecovery();
@@ -567,6 +571,7 @@ export function SellPage() {
       title,
       description: description || undefined,
       priceSats,
+      downloadWindowSeconds,
       peekMode,
       previewLineLimit: activePreviewPreset.lineLimit,
       previewMaxChars: activePreviewPreset.maxChars,
@@ -969,6 +974,30 @@ export function SellPage() {
                        focus:outline-none focus:border-orange-500"
             />
             {priceError && <p className="mt-2 text-red-400 text-sm">{priceError}</p>}
+          </div>
+
+          <div>
+            <label className="block text-slate-300 mb-2">Re-download window</label>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {DOWNLOAD_WINDOW_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setDownloadWindowSeconds(option.value)}
+                  className={`rounded-xl border px-3 py-3 text-center text-sm font-semibold transition-colors ${
+                    downloadWindowSeconds === option.value
+                      ? 'border-orange-500 bg-orange-500/10 text-white'
+                      : 'border-slate-700 bg-slate-900/40 text-slate-400 hover:border-slate-500 hover:text-white'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+              Sets how long buyers can re-download on their device after paying. After it ends,
+              they'd pay again to get the file.
+            </p>
           </div>
         </div>
 

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -17,6 +17,7 @@ import {
   FileText,
   ShieldAlert,
   ShieldCheck,
+  Clock,
 } from 'lucide-react';
 import { useUnlock } from '../lib/useUnlock';
 import { createPayInvoice, checkPayStatus } from '../lib/api';
@@ -24,6 +25,18 @@ import { verifyGeneratedPreviewBundle } from '../lib/verifiedPreview';
 import type { StashProofSecret, TextPreviewMetadata } from '../../../shared/types';
 
 type PayTab = 'lightning' | 'cashu';
+
+function formatWindow(seconds: number): string {
+  const days = Math.max(1, Math.round(seconds / 86_400));
+  return `${days} day${days === 1 ? '' : 's'}`;
+}
+
+function formatDeadline(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
 
 export function UnlockPage() {
   const { id } = useParams<{ id: string }>();
@@ -99,6 +112,7 @@ export function UnlockPage() {
       blobSha256?: string;
       fileName?: string;
       claimToken?: string;
+      claimExpiresAt?: number;
       previewSecret?: StashProofSecret;
     }) => {
       unlock.submitLightningResult(data);
@@ -153,6 +167,7 @@ export function UnlockPage() {
               blobSha256: status.blobSha256,
               fileName: status.fileName,
               claimToken: status.claimToken,
+              claimExpiresAt: status.claimExpiresAt,
               previewSecret: status.previewSecret,
             });
           }
@@ -435,6 +450,43 @@ export function UnlockPage() {
             Download File
           </button>
 
+          {unlock.claimExpiresAt && (
+            <p className="mb-4 flex items-center justify-center gap-1.5 text-center text-xs text-slate-500">
+              <Clock className="h-3.5 w-3.5 shrink-0" />
+              You can re-download on this device until {formatDeadline(unlock.claimExpiresAt)}.
+            </p>
+          )}
+
+          <Link to="/" className="block text-slate-400 hover:text-white transition-colors">
+            ← Back to Home
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Re-download window ended — buyer paid before, but the claim token has expired
+  if (unlock.status === 'expired') {
+    return (
+      <div className="min-h-screen bg-slate-900 flex items-center justify-center p-6">
+        <div className="max-w-lg w-full text-center">
+          <div className="w-20 h-20 mx-auto mb-6 bg-amber-500/20 rounded-2xl flex items-center justify-center">
+            <Clock className="w-10 h-10 text-amber-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-4">Re-download window ended</h1>
+          <p className="text-slate-400 mb-8">
+            Your previous payment let you re-download this file for a limited time, and that window
+            has now closed. To get the file again, you'll need to unlock it with a new payment.
+          </p>
+
+          <button
+            onClick={() => unlock.payAgain()}
+            className="btn-primary mb-4 w-full px-6 py-4 text-lg"
+          >
+            <LockOpen className="w-5 h-5" />
+            Unlock again
+          </button>
+
           <Link to="/" className="block text-slate-400 hover:text-white transition-colors">
             ← Back to Home
           </Link>
@@ -477,6 +529,14 @@ export function UnlockPage() {
               <p className="text-orange-400 font-bold text-xl">{unlock.stash?.priceSats} sats</p>
             </div>
           </div>
+
+          {unlock.stash && (
+            <p className="mt-4 flex items-center justify-center gap-1.5 text-center text-xs text-slate-500">
+              <Clock className="h-3.5 w-3.5 shrink-0" />
+              After paying, you can re-download on this device for{' '}
+              {formatWindow(unlock.stash.downloadWindowSeconds)}.
+            </p>
+          )}
 
           {unlock.stash?.generatedPreview && (
             <div

--- a/client/src/lib/useStash.ts
+++ b/client/src/lib/useStash.ts
@@ -25,6 +25,7 @@ export interface StashOptions {
   title: string;
   description?: string;
   priceSats: number;
+  downloadWindowSeconds: number;
   peekMode?: 'none' | 'auto' | 'excerpt';
   previewLineLimit?: TextLineLimit;
   previewMaxChars?: number;
@@ -103,6 +104,7 @@ export function useStash() {
         priceSats: options.priceSats,
         title: options.title,
         description: options.description,
+        downloadWindowSeconds: options.downloadWindowSeconds,
         fileName: file.name,
         fileSize: file.size,
         generatedPreview,

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -12,6 +12,7 @@ export type UnlockStatus =
   | 'unlocking'
   | 'decrypting'
   | 'done'
+  | 'expired'
   | 'error';
 
 export interface UnlockState {
@@ -21,6 +22,7 @@ export interface UnlockState {
   downloadUrl: string | null;
   fileName: string | null;
   blobSha256: string | null;
+  claimExpiresAt: number | null;
 }
 
 export function useUnlock(stashId: string) {
@@ -31,6 +33,7 @@ export function useUnlock(stashId: string) {
     downloadUrl: null,
     fileName: null,
     blobSha256: null,
+    claimExpiresAt: null,
   });
 
   const decryptAndFinish = useCallback(
@@ -40,6 +43,7 @@ export function useUnlock(stashId: string) {
       blobSha256?: string;
       fileName?: string;
       previewSecret?: StashProofSecret;
+      claimExpiresAt?: number;
     }) => {
       setState((s) => ({ ...s, status: 'decrypting', error: null }));
 
@@ -70,6 +74,7 @@ export function useUnlock(stashId: string) {
         downloadUrl,
         fileName,
         blobSha256: data.blobSha256 ?? null,
+        claimExpiresAt: data.claimExpiresAt ?? null,
       }));
     },
     [state.stash]
@@ -109,8 +114,14 @@ export function useUnlock(stashId: string) {
       return true;
     } catch (error) {
       const status = (error as Error & { status?: number }).status;
-      if (status === 404 || status === 410) {
-        // Token is invalid or expired — remove it permanently
+      if (status === 410) {
+        // Re-download window ended — keep the token so the expired screen
+        // survives a page refresh (loadStash will re-enter 'claiming' → 'expired').
+        setState((s) => ({ ...s, status: 'expired', error: null }));
+        return false;
+      }
+      if (status === 404) {
+        // Token is unknown/invalid — drop it and fall back to the pay form
         localStorage.removeItem(`stashu-claim-${stashId}`);
       }
       // For transient errors (network, 500), keep the token for next attempt
@@ -122,6 +133,11 @@ export function useUnlock(stashId: string) {
       return false;
     }
   }, [stashId, decryptAndFinish]);
+
+  const payAgain = useCallback(() => {
+    localStorage.removeItem(`stashu-claim-${stashId}`);
+    setState((s) => ({ ...s, status: 'ready', error: null }));
+  }, [stashId]);
 
   const submitToken = useCallback(
     async (token: string) => {
@@ -173,6 +189,7 @@ export function useUnlock(stashId: string) {
       blobSha256?: string;
       fileName?: string;
       claimToken?: string;
+      claimExpiresAt?: number;
       previewSecret?: StashProofSecret;
     }) => {
       try {
@@ -204,6 +221,7 @@ export function useUnlock(stashId: string) {
       downloadUrl: null,
       fileName: null,
       blobSha256: null,
+      claimExpiresAt: null,
     });
   }, [state.downloadUrl]);
 
@@ -214,6 +232,7 @@ export function useUnlock(stashId: string) {
     submitToken,
     submitLightningResult,
     download,
+    payAgain,
     reset,
   };
 }

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -175,20 +175,8 @@ function cleanupStaleQuotes() {
     console.log(`🔄 Reset ${recovered.changes} stuck processing payments to pending`);
   }
 
-  // Null out expired claim tokens (column added in migration v5)
-  try {
-    const expiredClaims = db
-      .prepare(
-        `UPDATE payments SET claim_token = NULL, claim_expires_at = NULL
-         WHERE claim_token IS NOT NULL AND claim_expires_at < ?`
-      )
-      .run(Math.floor(Date.now() / 1000));
-    if (expiredClaims.changes > 0) {
-      console.log(`🧹 Cleaned up ${expiredClaims.changes} expired claim token(s)`);
-    }
-  } catch {
-    // Column doesn't exist yet (pre-migration v5), skip
-  }
+  // Keep expired claim tokens so /api/unlock/:id/claim can return 410
+  // instead of treating a known-but-expired local token as unknown.
 }
 
 // Run cleanup on startup and every 5 minutes
@@ -398,6 +386,14 @@ const currentVersion = (
           update.run(encrypt(row.blob_url), row.id);
         }
         console.log(`🔐 Encrypted ${rows.length} blob URL(s).`);
+      },
+    },
+    {
+      version: 11,
+      name: 'add download_window_seconds to stashes',
+      run: () => {
+        db.exec(`ALTER TABLE stashes ADD COLUMN download_window_seconds INTEGER DEFAULT NULL`);
+        console.log('⏳ Added download_window_seconds column to stashes.');
       },
     },
   ];

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -25,6 +25,7 @@ export interface StashRow {
   preview_proof: string | null; // encrypted public metadata
   preview_secret: string | null; // encrypted
   show_in_storefront: number;
+  download_window_seconds: number | null; // NULL = use DEFAULT_DOWNLOAD_WINDOW_SECONDS
   created_at: number;
 }
 

--- a/server/src/routes/claim.test.ts
+++ b/server/src/routes/claim.test.ts
@@ -17,6 +17,7 @@ process.env.DB_PATH = ':memory:';
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
+import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 
 // Mock Cashu module before any route imports
 mock.module('../lib/cashu.js', {
@@ -109,6 +110,59 @@ describe('Fresh Cashu payment returns claimToken', () => {
       payment.claim_expires_at > Math.floor(Date.now() / 1000),
       'claim_expires_at should be in the future'
     );
+  });
+});
+
+describe('Re-download window controls claim expiry', () => {
+  function insertStashWithWindow(windowSeconds: number | null, id = TEST_STASH.id) {
+    db.prepare(
+      `INSERT INTO stashes (id, blob_url, secret_key, seller_pubkey, price_sats, title, file_name, file_size, download_window_seconds)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      id,
+      encrypt(TEST_STASH.blobUrl),
+      encrypt(TEST_STASH.secretKey),
+      TEST_STASH.sellerPubkey,
+      TEST_STASH.priceSats,
+      encrypt('Test Stash'),
+      encrypt(TEST_STASH.fileName),
+      1024,
+      windowSeconds
+    );
+  }
+
+  it('sets claim_expires_at to now + the stash window on a fresh unlock', async () => {
+    insertStashWithWindow(86_400);
+    const before = Math.floor(Date.now() / 1000);
+
+    const res = await unlockApp.request(`/api/unlock/${TEST_STASH.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'cashuWindowToken' }),
+    });
+
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+    const after = Math.floor(Date.now() / 1000);
+    assert.ok(data.claimExpiresAt >= before + 86_400, 'expiry must honor the stash window');
+    assert.ok(data.claimExpiresAt <= after + 86_400, 'expiry must not exceed now + window');
+  });
+
+  it('falls back to the default window when the stash has none', async () => {
+    insertStashWithWindow(null);
+    const before = Math.floor(Date.now() / 1000);
+
+    const res = await unlockApp.request(`/api/unlock/${TEST_STASH.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'cashuDefaultWindowToken' }),
+    });
+
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+    const after = Math.floor(Date.now() / 1000);
+    assert.ok(data.claimExpiresAt >= before + DEFAULT_DOWNLOAD_WINDOW_SECONDS);
+    assert.ok(data.claimExpiresAt <= after + DEFAULT_DOWNLOAD_WINDOW_SECONDS);
   });
 });
 

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -14,25 +14,27 @@ import type {
   StashProofSecret,
   APIResponse,
 } from '../../../shared/types.js';
+import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 import type { StashRow, PaymentRow } from '../db/types.js';
 import { tryAutoSettle } from '../lib/autosettle.js';
 
 function ensureClaimToken(
   payment: Pick<PaymentRow, 'claim_token' | 'claim_expires_at'>,
-  paymentId: string
-): string {
+  paymentId: string,
+  windowSeconds: number
+): { claimToken: string; claimExpiresAt: number } {
   const now = Math.floor(Date.now() / 1000);
   if (payment.claim_token && payment.claim_expires_at && payment.claim_expires_at >= now) {
-    return payment.claim_token;
+    return { claimToken: payment.claim_token, claimExpiresAt: payment.claim_expires_at };
   }
   const claimToken = randomBytes(32).toString('hex');
-  const claimExpiresAt = now + 3600;
+  const claimExpiresAt = now + windowSeconds;
   db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
     claimToken,
     claimExpiresAt,
     paymentId
   );
-  return claimToken;
+  return { claimToken, claimExpiresAt };
 }
 
 function decryptPreviewSecret(value: string | null): StashProofSecret | undefined {
@@ -108,14 +110,24 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
     if (existingPayment.status === 'paid') {
       const stash = db
         .prepare(
-          'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name FROM stashes WHERE id = ?'
+          'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name, download_window_seconds FROM stashes WHERE id = ?'
         )
         .get(stashId) as Pick<
         StashRow,
-        'secret_key' | 'blob_url' | 'blob_sha256' | 'preview_secret' | 'file_name'
+        | 'secret_key'
+        | 'blob_url'
+        | 'blob_sha256'
+        | 'preview_secret'
+        | 'file_name'
+        | 'download_window_seconds'
       >;
 
-      const claimToken = ensureClaimToken(existingPayment, paymentId);
+      const windowSeconds = stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS;
+      const { claimToken, claimExpiresAt } = ensureClaimToken(
+        existingPayment,
+        paymentId,
+        windowSeconds
+      );
 
       return c.json<APIResponse<PayStatusResponse>>({
         success: true,
@@ -127,6 +139,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           fileName: decrypt(stash.file_name),
           previewSecret: decryptPreviewSecret(stash.preview_secret),
           claimToken,
+          claimExpiresAt,
         },
       });
     }
@@ -156,19 +169,26 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
       if (current?.status === 'paid') {
         const stash = db
           .prepare(
-            'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name FROM stashes WHERE id = ?'
+            'SELECT secret_key, blob_url, blob_sha256, preview_secret, file_name, download_window_seconds FROM stashes WHERE id = ?'
           )
           .get(stashId) as Pick<
           StashRow,
-          'secret_key' | 'blob_url' | 'blob_sha256' | 'preview_secret' | 'file_name'
+          | 'secret_key'
+          | 'blob_url'
+          | 'blob_sha256'
+          | 'preview_secret'
+          | 'file_name'
+          | 'download_window_seconds'
         >;
 
+        const windowSeconds = stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS;
         const paidRow = db
           .prepare('SELECT claim_token, claim_expires_at FROM payments WHERE id = ?')
           .get(paymentId) as Pick<PaymentRow, 'claim_token' | 'claim_expires_at'>;
-        const claimToken = ensureClaimToken(
+        const { claimToken, claimExpiresAt } = ensureClaimToken(
           paidRow ?? { claim_token: null, claim_expires_at: null },
-          paymentId
+          paymentId,
+          windowSeconds
         );
 
         return c.json<APIResponse<PayStatusResponse>>({
@@ -181,6 +201,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
             fileName: decrypt(stash.file_name),
             previewSecret: decryptPreviewSecret(stash.preview_secret),
             claimToken,
+            claimExpiresAt,
           },
         });
       }
@@ -204,7 +225,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
 
     const stash = db
       .prepare(
-        'SELECT id, price_sats, secret_key, blob_url, blob_sha256, preview_secret, file_name, seller_pubkey FROM stashes WHERE id = ?'
+        'SELECT id, price_sats, secret_key, blob_url, blob_sha256, preview_secret, file_name, seller_pubkey, download_window_seconds FROM stashes WHERE id = ?'
       )
       .get(stashId) as Pick<
       StashRow,
@@ -216,11 +237,14 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
       | 'preview_secret'
       | 'file_name'
       | 'seller_pubkey'
+      | 'download_window_seconds'
     > | null;
 
     if (!stash) {
       return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
     }
+
+    const windowSeconds = stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS;
 
     try {
       // Mint tokens from the paid invoice
@@ -247,7 +271,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
       }
 
       const claimToken = randomBytes(32).toString('hex');
-      const claimExpiresAt = Math.floor(Date.now() / 1000) + 3600; // 1hr
+      const claimExpiresAt = Math.floor(Date.now() / 1000) + windowSeconds;
 
       db.prepare(
         `UPDATE payments SET status = 'paid', seller_token = ?, claim_token = ?, claim_expires_at = ?, paid_at = unixepoch() WHERE id = ?`
@@ -268,6 +292,7 @@ payRoutes.get('/:id/status/:quoteId', async (c) => {
           fileName: decrypt(stash.file_name),
           previewSecret: decryptPreviewSecret(stash.preview_secret),
           claimToken,
+          claimExpiresAt,
         },
       });
     } catch (mintError) {

--- a/server/src/routes/seller.ts
+++ b/server/src/routes/seller.ts
@@ -7,6 +7,7 @@ import type {
   StashPublicInfo,
   APIResponse,
 } from '../../../shared/types.js';
+import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const sellerRoutes = new Hono();
@@ -56,7 +57,7 @@ sellerRoutes.get('/:pubkey', async (c) => {
 
     const stmt = db.prepare(`
       SELECT id, title, description, file_name, file_size, price_sats, preview_url,
-             generated_preview_payload, preview_proof, created_at
+             generated_preview_payload, preview_proof, download_window_seconds, created_at
       FROM stashes
       WHERE seller_pubkey = ? AND show_in_storefront = 1
       ORDER BY created_at DESC
@@ -73,6 +74,7 @@ sellerRoutes.get('/:pubkey', async (c) => {
       | 'preview_url'
       | 'generated_preview_payload'
       | 'preview_proof'
+      | 'download_window_seconds'
       | 'created_at'
     >[];
 
@@ -86,6 +88,7 @@ sellerRoutes.get('/:pubkey', async (c) => {
       previewUrl: row.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(row.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(row.preview_proof),
+      downloadWindowSeconds: row.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS,
     }));
 
     return c.json<APIResponse<StashPublicInfo[]>>({

--- a/server/src/routes/stash.test.ts
+++ b/server/src/routes/stash.test.ts
@@ -14,6 +14,7 @@ process.env.DB_PATH = ':memory:';
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
+import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 
 const db = (await import('../db/index.js')).default;
 const { decrypt } = await import('../lib/encryption.js');
@@ -156,6 +157,22 @@ describe('POST /api/stash', () => {
     assert.equal(body.success, true);
     assert.ok(body.data.id);
     assert.ok(body.data.shareUrl.startsWith('/s/'));
+  });
+
+  it('rejects a downloadWindowSeconds outside the allowed set', async () => {
+    const res = await createStash({ ...validBody(), downloadWindowSeconds: 12_345 });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /downloadWindowSeconds/i);
+  });
+
+  it('stores a valid downloadWindowSeconds', async () => {
+    const res = await createStash({ ...validBody(), downloadWindowSeconds: 86_400 });
+    assert.equal(res.status, 201);
+    const { data } = await res.json();
+    const row = db
+      .prepare('SELECT download_window_seconds FROM stashes WHERE id = ?')
+      .get(data.id) as { download_window_seconds: number };
+    assert.equal(row.download_window_seconds, 86_400);
   });
 
   it('stores generated preview proof fields when provided', async () => {
@@ -677,6 +694,24 @@ describe('GET /api/stash/:id', () => {
     const res = await app.request(`/api/stash/${created.id}`);
     const { data } = await res.json();
     assert.equal(data.description, 'A test description');
+  });
+
+  it('defaults downloadWindowSeconds when the seller did not set one', async () => {
+    const createRes = await createStash();
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}`);
+    const { data } = await res.json();
+    assert.equal(data.downloadWindowSeconds, DEFAULT_DOWNLOAD_WINDOW_SECONDS);
+  });
+
+  it('returns the seller-chosen downloadWindowSeconds', async () => {
+    const createRes = await createStash({ ...validBody(), downloadWindowSeconds: 2_592_000 });
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}`);
+    const { data } = await res.json();
+    assert.equal(data.downloadWindowSeconds, 2_592_000);
   });
 
   it('returns public generated preview proof but not preview secret', async () => {

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -12,6 +12,10 @@ import type {
   StashPublicInfo,
   APIResponse,
 } from '../../../shared/types.js';
+import {
+  ALLOWED_DOWNLOAD_WINDOW_SECONDS,
+  DEFAULT_DOWNLOAD_WINDOW_SECONDS,
+} from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const stashRoutes = new Hono<{ Variables: AuthVariables }>();
@@ -372,6 +376,16 @@ stashRoutes.post('/', async (c) => {
       );
     }
 
+    if (
+      body.downloadWindowSeconds !== undefined &&
+      !ALLOWED_DOWNLOAD_WINDOW_SECONDS.has(body.downloadWindowSeconds)
+    ) {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'downloadWindowSeconds must be one of the allowed values' },
+        400
+      );
+    }
+
     const previewError = validatePreviewBundle(body);
     if (previewError) {
       return c.json<APIResponse<never>>({ success: false, error: previewError }, 400);
@@ -383,9 +397,9 @@ stashRoutes.post('/', async (c) => {
       INSERT INTO stashes (
         id, blob_url, blob_sha256, secret_key, seller_pubkey, price_sats,
         title, description, file_name, file_size, preview_url,
-        generated_preview_payload, preview_proof, preview_secret
+        generated_preview_payload, preview_proof, preview_secret, download_window_seconds
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -402,7 +416,8 @@ stashRoutes.post('/', async (c) => {
       body.previewUrl || null,
       body.generatedPreview ? stringifyEncryptedJson(body.generatedPreview) : null,
       body.previewProof ? stringifyEncryptedJson(body.previewProof) : null,
-      body.previewSecret ? stringifyEncryptedJson(body.previewSecret) : null
+      body.previewSecret ? stringifyEncryptedJson(body.previewSecret) : null,
+      body.downloadWindowSeconds ?? null
     );
 
     const shareUrl = `/s/${id}`;
@@ -495,7 +510,7 @@ stashRoutes.get('/:id', async (c) => {
 
     const stmt = db.prepare(`
       SELECT id, title, description, file_name, file_size, price_sats, preview_url,
-             generated_preview_payload, preview_proof
+             generated_preview_payload, preview_proof, download_window_seconds
       FROM stashes WHERE id = ?
     `);
 
@@ -510,6 +525,7 @@ stashRoutes.get('/:id', async (c) => {
       | 'preview_url'
       | 'generated_preview_payload'
       | 'preview_proof'
+      | 'download_window_seconds'
     > | null;
 
     if (!stash) {
@@ -533,6 +549,7 @@ stashRoutes.get('/:id', async (c) => {
       previewUrl: stash.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(stash.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(stash.preview_proof),
+      downloadWindowSeconds: stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS,
     };
 
     return c.json<APIResponse<StashPublicInfo>>({

--- a/server/src/routes/unlock.test.ts
+++ b/server/src/routes/unlock.test.ts
@@ -182,6 +182,7 @@ describe('GET /api/unlock/:id/claim', () => {
     assert.equal(data.blobUrl, TEST_STASH.blobUrl);
     assert.equal(data.fileName, TEST_STASH.fileName);
     assert.deepEqual(data.previewSecret, PREVIEW_SECRET);
+    assert.equal(data.claimExpiresAt, expiresAt);
   });
 
   it('returns 400 when token query param is missing', async () => {

--- a/server/src/routes/unlock.ts
+++ b/server/src/routes/unlock.ts
@@ -11,6 +11,7 @@ import type {
   UnlockResponse,
   APIResponse,
 } from '../../../shared/types.js';
+import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 import type { StashRow, PaymentRow } from '../db/types.js';
 
 export const unlockRoutes = new Hono();
@@ -37,7 +38,7 @@ unlockRoutes.post('/:id', async (c) => {
 
     // Get stash details
     const stashStmt = db.prepare(`
-      SELECT id, blob_url, blob_sha256, secret_key, preview_secret, file_name, price_sats, seller_pubkey
+      SELECT id, blob_url, blob_sha256, secret_key, preview_secret, file_name, price_sats, seller_pubkey, download_window_seconds
       FROM stashes WHERE id = ?
     `);
     const stash = stashStmt.get(stashId) as Pick<
@@ -50,6 +51,7 @@ unlockRoutes.post('/:id', async (c) => {
       | 'file_name'
       | 'price_sats'
       | 'seller_pubkey'
+      | 'download_window_seconds'
     > | null;
 
     if (!stash) {
@@ -62,6 +64,8 @@ unlockRoutes.post('/:id', async (c) => {
       );
     }
 
+    const windowSeconds = stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS;
+
     // Create payment ID from full token hash (for idempotency)
     const tokenHash = createHash('sha256').update(body.token).digest('hex');
     const paymentId = `${stashId}-${tokenHash}`;
@@ -73,9 +77,12 @@ unlockRoutes.post('/:id', async (c) => {
 
     if (existingPayment) {
       if (existingPayment.status === 'paid') {
-        // Already paid - return the key (idempotent)
-        // Regenerate claim token if missing or expired
+        // Already paid - return the key (idempotent). Regenerate the claim token if
+        // missing/expired. NOTE: re-submitting the original payment token deliberately
+        // grants a fresh window past expiry — proof-of-payment recovery, intentionally
+        // softer than GET /claim's hard 410. Don't "fix" this mismatch.
         let claimToken = existingPayment.claim_token;
+        let claimExpiresAt = existingPayment.claim_expires_at;
         const now = Math.floor(Date.now() / 1000);
         if (
           !claimToken ||
@@ -83,7 +90,7 @@ unlockRoutes.post('/:id', async (c) => {
           existingPayment.claim_expires_at < now
         ) {
           claimToken = randomBytes(32).toString('hex');
-          const claimExpiresAt = now + 3600;
+          claimExpiresAt = now + windowSeconds;
           db.prepare(`UPDATE payments SET claim_token = ?, claim_expires_at = ? WHERE id = ?`).run(
             claimToken,
             claimExpiresAt,
@@ -99,6 +106,7 @@ unlockRoutes.post('/:id', async (c) => {
             fileName: decrypt(stash.file_name),
             previewSecret: decryptPreviewSecret(stash.preview_secret),
             claimToken,
+            claimExpiresAt: claimExpiresAt ?? undefined,
           },
         });
       } else if (existingPayment.status === 'pending') {
@@ -153,7 +161,7 @@ unlockRoutes.post('/:id', async (c) => {
     }
 
     const claimToken = randomBytes(32).toString('hex');
-    const claimExpiresAt = Math.floor(Date.now() / 1000) + 3600; // 1hr
+    const claimExpiresAt = Math.floor(Date.now() / 1000) + windowSeconds;
 
     db.prepare(
       `
@@ -178,6 +186,7 @@ unlockRoutes.post('/:id', async (c) => {
         fileName: decrypt(stash.file_name),
         previewSecret: decryptPreviewSecret(stash.preview_secret),
         claimToken,
+        claimExpiresAt,
       },
     });
   } catch (error) {
@@ -239,6 +248,7 @@ unlockRoutes.get('/:id/claim', rateLimit(60_000, 10, '/api/unlock/claim'), async
       blobSha256: stash.blob_sha256 ?? undefined,
       fileName: decrypt(stash.file_name),
       previewSecret: decryptPreviewSecret(stash.preview_secret),
+      claimExpiresAt: payment.claim_expires_at,
     },
   });
 });

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@stashu/shared",
   "version": "0.2.0",
+  "type": "module",
   "main": "types.ts",
   "types": "types.ts"
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -101,7 +101,31 @@ export interface StashPublicInfo {
   previewUrl?: string;
   generatedPreview?: GeneratedPreviewPayload;
   previewProof?: StashProof;
+  // How long (seconds) a buyer can re-download on their device after paying.
+  // Always resolved server-side (legacy stashes fall back to the default).
+  downloadWindowSeconds: number;
 }
+
+// ============================================
+// Re-download window
+// ============================================
+
+// Per-stash re-download grace period: how long after paying a buyer can
+// re-download on the same device using their claim token. Seller picks one
+// of these on /sell. Day-based only — no hour granularity, no "never".
+export const DOWNLOAD_WINDOW_OPTIONS = [
+  { value: 86_400, label: '1 day' },
+  { value: 604_800, label: '7 days' },
+  { value: 2_592_000, label: '30 days' },
+] as const;
+
+// Used when a seller doesn't choose, and for legacy stashes created before
+// this feature (stored window is NULL).
+export const DEFAULT_DOWNLOAD_WINDOW_SECONDS = 604_800; // 7 days
+
+export const ALLOWED_DOWNLOAD_WINDOW_SECONDS: ReadonlySet<number> = new Set(
+  DOWNLOAD_WINDOW_OPTIONS.map((option) => option.value)
+);
 
 // ============================================
 // Payment Types
@@ -138,6 +162,8 @@ export interface CreateStashRequest {
   generatedPreview?: GeneratedPreviewPayload;
   previewProof?: StashProof;
   previewSecret?: StashProofSecret;
+  // One of DOWNLOAD_WINDOW_OPTIONS. Omitted falls back to the default server-side.
+  downloadWindowSeconds?: number;
 }
 
 export interface CreateStashResponse {
@@ -156,6 +182,7 @@ export interface UnlockResponse {
   blobSha256?: string;
   fileName: string;
   claimToken?: string;
+  claimExpiresAt?: number; // unix seconds — when the re-download window ends
   previewSecret?: StashProofSecret;
 }
 
@@ -223,6 +250,7 @@ export interface PayStatusResponse {
   blobSha256?: string;
   fileName?: string;
   claimToken?: string;
+  claimExpiresAt?: number; // unix seconds — when the re-download window ends
   previewSecret?: StashProofSecret;
 }
 


### PR DESCRIPTION
Fixes #60
Sellers can now pick how long buyers can re-download after paying (1/7/30 days, default 7). Once it's up, they just pay again. Replaces the old fixed 1-hour expiry.
Old stashes default to 7 days, so nothing breaks.