### PR TITLE
Bind Verified Peek to sealed stash packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Stashu is a privacy-first pay-to-unlock file marketplace. Sellers create a stash
 in the browser, buyers unlock it with Lightning or Cashu ecash, and no platform
 account is required.
 
-- **Client-side encryption** - files are encrypted in the browser before upload.
-- **Blossom storage** - encrypted blobs are stored on Blossom servers instead of
+- **Client-side sealing** - hidden file regions are encrypted in the browser
+  before upload. Any seller-selected preview is intentionally public.
+- **Blossom storage** - sealed blobs are stored on Blossom servers instead of
   inside the app database.
 - **Verified Peek** - optional previews are generated from the file itself and
   checked again after unlock.
@@ -40,12 +41,13 @@ account is required.
 
 1. **Seller creates a stash** - selects a file, title, price, and optional buyer
    preview.
-2. **Browser encrypts the file** - plaintext stays local. The encrypted blob is
-   uploaded to Blossom.
+2. **Browser seals the file** - hidden plaintext stays local. New stashes are
+   packed into an authenticated selective-reveal blob and uploaded to Blossom.
 3. **Server stores stash state** - encrypted metadata, payment state, and preview
    proof data are saved in SQLite.
 4. **Buyer opens the stash** - public metadata and any Verified Peek data are
-   loaded before payment.
+   loaded before payment. When a public peek exists, the buyer also fetches and
+   hash-checks the sealed Blossom blob before payment is enabled.
 5. **Buyer pays** - either by paying a Lightning invoice or pasting a Cashu ecash
    token.
 6. **Browser unlocks the file** - after payment, the server returns the decryption
@@ -55,9 +57,13 @@ account is required.
 
 ## Verified Peek
 
-Verified Peek adds a buyer-side integrity check. If a seller shows a preview, it
-is generated from the selected file in the browser, then tied to the same
-encrypted content the buyer unlocks later.
+Verified Peek adds a buyer-side integrity check. If a seller shows text publicly,
+the new sealed blob stores that exact excerpt as a public segment between
+encrypted hidden segments. The buyer fetches and hash-checks the sealed blob
+before payment, then reconstructs and verifies the complete file after unlock.
+New text peeks require this v2 sealed-package flow. Existing v1 links remain
+unlockable, but the buyer page labels their weaker prepayment assurance as
+`Legacy Peek`.
 
 <div align="center">
   <img src="docs/verified-peek.png" alt="Verified Peek flow" width="900">
@@ -66,7 +72,10 @@ encrypted content the buyer unlocks later.
 What it gives buyers:
 
 - Preview text is generated from the selected file in the seller's browser.
-- The buyer page checks the published preview proof before enabling payment.
+- The buyer page checks the published preview proof and sealed Blossom blob
+  before enabling payment.
+- The public excerpt is a literal segment used when reconstructing the locked
+  file, rather than a detached text sample.
 - After payment, the decrypted file is checked against the same content
   commitment before the download is shown as verified.
 - If the preview proof or unlocked file does not match, Stashu blocks payment or
@@ -75,9 +84,13 @@ What it gives buyers:
 Under the hood:
 
 - The browser serializes the generated preview and hashes it.
-- The file is committed with a Merkle-style root over file chunks.
+- Hidden file regions are encrypted with XChaCha20-Poly1305. The public excerpt,
+  when present, is stored as a plaintext region in the sealed blob.
+- The exact sealed blob is addressed and checked by its SHA-256 hash.
+- The reconstructed file is committed with a Merkle-style root over file chunks.
 - If text is shown publicly, that exact range gets an inclusion proof.
-- The final proof root ties the preview hash to the content root.
+- V2 proof roots tie the preview hash, reconstructed content root, and sealed
+  blob hash together.
 - The server stores the proof data, but the proof secret needed for the final file
   check is returned only after unlock.
 
@@ -99,19 +112,21 @@ get a no-public-preview commitment check after unlock.
 
 ## Security Model
 
-Stashu V1 is a trusted escrow. In the normal flow, plaintext files stay
+Stashu V1 is a trusted escrow. In the normal flow, hidden plaintext stays
 client-side, but the server still coordinates payment and returns the file key
 after a valid unlock.
 
 ### Protected Today
 
-- **Plaintext file contents** stay in the seller and buyer browsers during normal
-  use. Blossom stores ciphertext.
+- **Hidden file contents** stay in the seller and buyer browsers during normal
+  use. Blossom stores encrypted hidden regions plus any intentionally public
+  preview excerpt.
 - **Sensitive database fields** are encrypted at rest, including stash metadata,
   blob URLs, file keys, preview proof fields, seller payment tokens, and Lightning
   addresses.
-- **Verified Peek integrity** checks that a public preview belongs to the committed
-  file, then checks the unlocked file again after payment.
+- **Verified Peek integrity** checks that a public text excerpt is a literal
+  segment of the hash-verified sealed blob before payment, then checks the
+  reconstructed file against its content commitment after unlock.
 - **Seller auth** uses NIP-98 signatures from the seller's local Nostr keypair.
 - **Payment integrity** uses quote-to-stash binding, processing locks, and
   idempotent unlock paths to guard against replay and double-processing bugs.
@@ -119,15 +134,17 @@ after a valid unlock.
 
 ### Known Limits
 
-| Limit                  | Details                                                                                                                                                                                                               |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Trusted server         | The server currently stores encrypted file keys and decides when to release them after payment.                                                                                                                       |
-| Server compromise      | `TOKEN_ENCRYPTION_KEY` is co-located with the database. A root compromise can decrypt encrypted database fields.                                                                                                      |
-| Payment custody        | Seller Cashu tokens are held by the server until withdrawal or auto-settlement.                                                                                                                                       |
-| Browser key storage    | The seller Nostr private key lives in browser local storage.                                                                                                                                                          |
-| Preview privacy        | Verified Peek reveals the selected preview before payment. Stashu uses conservative defaults and limits, but the seller still chooses what to show.                                                                   |
-| Single mint dependency | The server currently uses one configured Cashu mint through `MINT_URL`.                                                                                                                                               |
-| Re-download window     | Buyers re-download with a per-device claim token in browser local storage that expires after the seller's window (1-30 days, default 7). It is not a shareable link, so clearing the browser ends re-download access. |
+| Limit                  | Details                                                                                                                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Trusted server         | The server currently stores encrypted file keys and decides when to release them after payment.                                                                                                                                                                          |
+| Server compromise      | `TOKEN_ENCRYPTION_KEY` is co-located with the database. A root compromise can decrypt encrypted database fields.                                                                                                                                                         |
+| Payment custody        | Seller Cashu tokens are held by the server until withdrawal or auto-settlement.                                                                                                                                                                                          |
+| Browser key storage    | The seller Nostr private key lives in browser local storage.                                                                                                                                                                                                             |
+| Preview privacy        | Verified Peek reveals the selected preview before payment. Stashu uses conservative defaults and limits, but the seller still chooses what to show.                                                                                                                      |
+| Seller quality         | Verified Peek proves that the public excerpt is used by the locked package. It cannot prove before unlock that hidden regions are useful, representative, or decrypt successfully. A dishonest seller can still sell low-quality content or deliberately break delivery. |
+| Prepayment bandwidth   | Sealed blobs with a public peek are fetched and hash-checked before payment so the buyer can verify the locked package. Large previewed files therefore consume download bandwidth before unlock.                                                                        |
+| Single mint dependency | The server currently uses one configured Cashu mint through `MINT_URL`.                                                                                                                                                                                                  |
+| Re-download window     | Buyers re-download with a per-device claim token in browser local storage that expires after the seller's window (1-30 days, default 7). It is not a shareable link, so clearing the browser ends re-download access.                                                    |
 
 ## Quick Start
 
@@ -158,6 +175,8 @@ Server:
 - `PORT` - server port. Defaults to `3000`.
 - `DB_PATH` - SQLite database path.
 - `TRUSTED_PROXY` - set to `1` only when running behind a trusted proxy.
+- `ALLOW_INSECURE_BLOSSOM_URLS` - set to `1` only for intentional local development with
+  HTTP or private-network Blossom URLs.
 
 Client:
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Server:
 
 - `TOKEN_ENCRYPTION_KEY` - 64 hex chars. Required.
 - `MINT_URL` - Cashu mint URL.
+- `CASHU_REQUEST_TIMEOUT_MS` - abort unresponsive mint requests. Defaults to `10000`.
 - `CORS_ORIGINS` - comma-separated allowed origins.
 - `PORT` - server port. Defaults to `3000`.
 - `DB_PATH` - SQLite database path.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
                 step: 1,
                 icon: <Lock className="w-5 h-5 text-orange-400" />,
                 title: 'Encrypt & Upload',
-                desc: 'Your file is encrypted in-browser before upload. The server never sees it.',
+                desc: 'Hidden file regions are encrypted in-browser. Any preview you choose is intentionally public.',
               },
               {
                 step: 2,
@@ -131,9 +131,7 @@ function App() {
             Support
           </a>
         </div>
-        <p className="text-xs text-slate-600">
-          100% client-side encryption • Your keys, your files
-        </p>
+        <p className="text-xs text-slate-600">Client-side sealing • Your keys, your files</p>
       </footer>
     </div>
   );

--- a/client/src/components/UnlockPage.tsx
+++ b/client/src/components/UnlockPage.tsx
@@ -22,6 +22,7 @@ import {
 import { useUnlock } from '../lib/useUnlock';
 import { createPayInvoice, checkPayStatus } from '../lib/api';
 import { verifyGeneratedPreviewBundle } from '../lib/verifiedPreview';
+import { STASH_BLOB_FORMAT } from '../lib/stashPackage';
 import type { StashProofSecret, TextPreviewMetadata } from '../../../shared/types';
 
 type PayTab = 'lightning' | 'cashu';
@@ -76,6 +77,11 @@ export function UnlockPage() {
     };
   }, [unlock.stash?.generatedPreview]);
   const previewProofInvalid = previewVerification.state === 'invalid';
+  const legacyTextPeek =
+    unlock.stash?.generatedPreview?.kind === 'text-peek' &&
+    (unlock.stash.blobFormat !== STASH_BLOB_FORMAT ||
+      unlock.stash.previewProof?.version !== 'stashu-preview-v2' ||
+      unlock.stash.previewProof.sealedBlobSha256 !== unlock.stash.blobSha256);
 
   useEffect(() => {
     if (id) {
@@ -543,25 +549,35 @@ export function UnlockPage() {
               className={`mt-5 rounded-xl border p-4 ${
                 previewVerification.state === 'invalid'
                   ? 'border-rose-500/40 bg-rose-500/10'
-                  : 'border-emerald-500/30 bg-emerald-500/10'
+                  : legacyTextPeek
+                    ? 'border-amber-500/40 bg-amber-500/10'
+                    : 'border-emerald-500/30 bg-emerald-500/10'
               }`}
             >
               <div className="flex items-center gap-2 mb-3">
-                {previewVerification.state === 'invalid' ? (
-                  <ShieldAlert className="w-4 h-4 text-rose-400" />
+                {previewVerification.state === 'invalid' || legacyTextPeek ? (
+                  <ShieldAlert
+                    className={`w-4 h-4 ${legacyTextPeek ? 'text-amber-400' : 'text-rose-400'}`}
+                  />
                 ) : (
                   <ShieldCheck className="w-4 h-4 text-emerald-400" />
                 )}
                 <p
                   className={`text-sm font-semibold ${
-                    previewVerification.state === 'invalid' ? 'text-rose-300' : 'text-emerald-300'
+                    previewVerification.state === 'invalid'
+                      ? 'text-rose-300'
+                      : legacyTextPeek
+                        ? 'text-amber-300'
+                        : 'text-emerald-300'
                   }`}
                 >
                   {previewVerification.state === 'invalid'
                     ? 'Stash verification failed'
-                    : previewVerification.text !== undefined
-                      ? 'Verified Peek'
-                      : 'File verification ready'}
+                    : legacyTextPeek
+                      ? 'Legacy Peek'
+                      : previewVerification.text !== undefined
+                        ? 'Verified Peek'
+                        : 'File verification ready'}
                 </p>
               </div>
 
@@ -579,6 +595,12 @@ export function UnlockPage() {
                     <p className="mt-3 text-left text-xs text-slate-500">
                       {previewStats.bytes.toLocaleString()} bytes · {previewStats.percent}% ·{' '}
                       {previewStats.lines} line{previewStats.lines === 1 ? '' : 's'}
+                    </p>
+                  )}
+                  {legacyTextPeek && (
+                    <p className="mt-3 rounded-lg bg-amber-950/40 p-3 text-left text-xs text-amber-100/80">
+                      This older stash checks the preview commitment now and the complete file after
+                      unlock. It does not bind the locked blob before payment.
                     </p>
                   )}
                 </>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
 import { createAuthHeader } from './auth';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+const INVOICE_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Create a new stash on the backend
@@ -161,9 +162,18 @@ export async function executeWithdraw(
  * Create a Lightning invoice for paying for a stash
  */
 export async function createPayInvoice(stashId: string): Promise<PayInvoiceResponse> {
-  const response = await fetch(`${API_BASE}/pay/${stashId}/invoice`, {
-    method: 'POST',
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}/pay/${stashId}/invoice`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(INVOICE_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+      throw new Error('Invoice request timed out. Please try again shortly.');
+    }
+    throw error;
+  }
 
   const result: APIResponse<PayInvoiceResponse> = await response.json();
 

--- a/client/src/lib/blossom.test.ts
+++ b/client/src/lib/blossom.test.ts
@@ -39,7 +39,7 @@ vi.mock('./nostr.js', () => ({
   ),
 }));
 
-import { mirrorToBlossom, uploadToBlossom } from './blossom.js';
+import { fetchFromBlossomWithFallback, mirrorToBlossom, uploadToBlossom } from './blossom.js';
 
 describe('Blossom protocol client', () => {
   beforeEach(() => {
@@ -102,5 +102,36 @@ describe('Blossom protocol client', () => {
     expect(token).toMatch(/^[A-Za-z0-9\-_]+$/);
     expect(token).not.toContain('=');
     expect(init.body).toBe(JSON.stringify({ url: 'https://source.example.com/ciphertext' }));
+  });
+
+  it('rejects downloaded bytes that do not match the Blossom hash', async () => {
+    const expectedHash = sha256(new TextEncoder().encode('expected'));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode('swapped').buffer,
+      })
+    );
+
+    await expect(
+      fetchFromBlossomWithFallback(`https://blossom.primal.net/${expectedHash}`, expectedHash)
+    ).rejects.toThrow(/hash did not match/i);
+  });
+
+  it('rejects oversized downloads before using them as sealed packages', async () => {
+    const data = new TextEncoder().encode('too large');
+    const expectedHash = sha256(data);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => data.buffer,
+      })
+    );
+
+    await expect(
+      fetchFromBlossomWithFallback(`https://blossom.primal.net/${expectedHash}`, expectedHash, 4)
+    ).rejects.toThrow(/allowed size/i);
   });
 });

--- a/client/src/lib/blossom.ts
+++ b/client/src/lib/blossom.ts
@@ -120,14 +120,48 @@ export async function uploadToBlossom(
  * Get file from Blossom server
  * @param url The Blossom blob URL
  */
-export async function fetchFromBlossom(url: string): Promise<Uint8Array> {
+export async function fetchFromBlossom(url: string, maxBytes?: number): Promise<Uint8Array> {
   const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch from Blossom: ${response.status}`);
   }
 
+  const declaredLength = response.headers?.get('content-length');
+  if (maxBytes !== undefined && declaredLength && Number(declaredLength) > maxBytes) {
+    throw new Error('Downloaded blob exceeds the allowed size');
+  }
+
+  if (maxBytes !== undefined && response.body) {
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalLength = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalLength += value.length;
+      if (totalLength > maxBytes) {
+        await reader.cancel();
+        throw new Error('Downloaded blob exceeds the allowed size');
+      }
+      chunks.push(value);
+    }
+
+    const blob = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      blob.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return blob;
+  }
+
   const buffer = await response.arrayBuffer();
+  if (maxBytes !== undefined && buffer.byteLength > maxBytes) {
+    throw new Error('Downloaded blob exceeds the allowed size');
+  }
   return new Uint8Array(buffer);
 }
 
@@ -183,23 +217,41 @@ export function mirrorToBackupServers(
  */
 export async function fetchFromBlossomWithFallback(
   primaryUrl: string,
-  blobSha256: string | null | undefined
+  blobSha256: string | null | undefined,
+  maxBytes?: number
 ): Promise<Uint8Array> {
+  const fetchVerified = async (url: string) => {
+    const blob = await fetchFromBlossom(url, maxBytes);
+    if (blobSha256 && sha256(blob) !== blobSha256) {
+      throw new Error('Downloaded blob hash did not match its Blossom address');
+    }
+    return blob;
+  };
+
   // Try primary first
   try {
-    return await fetchFromBlossom(primaryUrl);
+    return await fetchVerified(primaryUrl);
   } catch (primaryError) {
     if (!blobSha256) throw primaryError;
+    let lastError = primaryError;
 
     // Try each mirror server
     for (const server of MIRROR_SERVERS) {
       try {
         const fallbackUrl = `${server}/${blobSha256}`;
         if (fallbackUrl === primaryUrl) continue;
-        return await fetchFromBlossom(fallbackUrl);
-      } catch {
+        return await fetchVerified(fallbackUrl);
+      } catch (error) {
+        lastError = error;
         continue;
       }
+    }
+
+    if (
+      lastError instanceof Error &&
+      /hash did not match|exceeds the allowed size/i.test(lastError.message)
+    ) {
+      throw lastError;
     }
 
     throw new Error(

--- a/client/src/lib/bytes.ts
+++ b/client/src/lib/bytes.ts
@@ -1,0 +1,38 @@
+export function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+export function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+export function concat(parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+
+  return result;
+}
+
+export function uint32Bytes(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, false);
+  return bytes;
+}
+
+export function uint64Bytes(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Offsets must be safe non-negative integers');
+  }
+
+  const bytes = new Uint8Array(8);
+  new DataView(bytes.buffer).setBigUint64(0, BigInt(value), false);
+  return bytes;
+}

--- a/client/src/lib/crypto.test.ts
+++ b/client/src/lib/crypto.test.ts
@@ -67,7 +67,7 @@ describe('encryptFile / decryptFile', () => {
     const { ciphertext, nonce, key } = await encryptFile(data.buffer as ArrayBuffer);
     const decrypted = await decryptFile(ciphertext, key, nonce);
     expect(new Uint8Array(decrypted)).toEqual(data);
-  });
+  }, 15_000);
 
   it('wrong key fails to decrypt', async () => {
     const data = new TextEncoder().encode('secret');

--- a/client/src/lib/stashPackage.test.ts
+++ b/client/src/lib/stashPackage.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSealedStashPackage,
+  decryptSealedStashPackage,
+  parseSealedStashPackage,
+  verifySealedStashPackage,
+} from './stashPackage.js';
+import { sha256 } from './crypto.js';
+
+const encoder = new TextEncoder();
+
+function bytes(value: string): Uint8Array {
+  return encoder.encode(value);
+}
+
+describe('sealed selective-reveal stash packages', () => {
+  it('roundtrips a file with a public middle excerpt and encrypted neighbors', () => {
+    const content = bytes('intro\npublic excerpt\npaid-only ending');
+    const excerpt = bytes('public excerpt');
+    const offset = bytes('intro\n').length;
+    const sealed = createSealedStashPackage(content, { offset, bytes: excerpt });
+
+    expect(sealed.blobSha256).toBe(sha256(sealed.blob));
+    expect(sealed.secretKey).toMatch(/^stashu-selective-v1:/);
+    expect(
+      verifySealedStashPackage(sealed.blob, sealed.blobSha256, { offset, bytes: excerpt })
+    ).toBe(true);
+
+    const stashPackage = parseSealedStashPackage(sealed.blob);
+    expect(stashPackage.contentLength).toBe(content.length);
+    expect(stashPackage.segments.map((segment) => segment.visibility)).toEqual([
+      'encrypted',
+      'public',
+      'encrypted',
+    ]);
+    expect(new Uint8Array(decryptSealedStashPackage(sealed.blob, sealed.secretKey))).toEqual(
+      content
+    );
+  });
+
+  it('roundtrips a fully private file without a public excerpt', () => {
+    const content = bytes('entirely private');
+    const sealed = createSealedStashPackage(content);
+
+    expect(verifySealedStashPackage(sealed.blob, sealed.blobSha256)).toBe(true);
+    expect(parseSealedStashPackage(sealed.blob).segments).toHaveLength(1);
+    expect(new Uint8Array(decryptSealedStashPackage(sealed.blob, sealed.secretKey))).toEqual(
+      content
+    );
+  });
+
+  it('rejects a detached public excerpt before payment', () => {
+    const content = bytes('real excerpt\npaid-only ending');
+    const sealed = createSealedStashPackage(content, {
+      offset: 0,
+      bytes: bytes('real excerpt'),
+    });
+
+    expect(
+      verifySealedStashPackage(sealed.blob, sealed.blobSha256, {
+        offset: 0,
+        bytes: bytes('bait excerpt'),
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a swapped sealed blob before payment', () => {
+    const first = createSealedStashPackage(bytes('same excerpt\nfirst hidden'), {
+      offset: 0,
+      bytes: bytes('same excerpt'),
+    });
+    const second = createSealedStashPackage(bytes('same excerpt\nsecond hidden'), {
+      offset: 0,
+      bytes: bytes('same excerpt'),
+    });
+
+    expect(
+      verifySealedStashPackage(second.blob, first.blobSha256, {
+        offset: 0,
+        bytes: bytes('same excerpt'),
+      })
+    ).toBe(false);
+  });
+
+  it('authenticates encrypted segment metadata and ciphertext during unlock', () => {
+    const content = bytes('public\nhidden');
+    const sealed = createSealedStashPackage(content, {
+      offset: 0,
+      bytes: bytes('public'),
+    });
+    const tampered = sealed.blob.slice();
+    tampered[tampered.length - 1] ^= 1;
+
+    expect(() => decryptSealedStashPackage(tampered, sealed.secretKey, sha256(tampered))).toThrow();
+  });
+
+  it('rejects trailing bytes and wrong keys', () => {
+    const sealed = createSealedStashPackage(bytes('secret'));
+    const withTrailingByte = new Uint8Array(sealed.blob.length + 1);
+    withTrailingByte.set(sealed.blob);
+
+    expect(() => parseSealedStashPackage(withTrailingByte)).toThrow(/coverage/);
+    expect(() =>
+      decryptSealedStashPackage(sealed.blob, `stashu-selective-v1:${btoa('wrong')}`)
+    ).toThrow(/length/);
+  });
+
+  it('rejects packages that claim an oversized reconstructed file', () => {
+    const sealed = createSealedStashPackage(bytes('secret'));
+    const oversized = sealed.blob.slice();
+    new DataView(oversized.buffer).setBigUint64(8, BigInt(100 * 1024 * 1024 + 1), false);
+
+    expect(() => parseSealedStashPackage(oversized)).toThrow(/shape/);
+  });
+});

--- a/client/src/lib/stashPackage.ts
+++ b/client/src/lib/stashPackage.ts
@@ -1,0 +1,360 @@
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+import { fromBase64, generateKey, sha256, toBase64 } from './crypto';
+
+export const STASH_BLOB_FORMAT = 'stashu-selective-v1' as const;
+
+const KEY_PREFIX = `${STASH_BLOB_FORMAT}:`;
+const MAGIC = new TextEncoder().encode('STASHU01');
+const NONCE_LENGTH = 24;
+const TAG_LENGTH = 16;
+const PACKAGE_HEADER_LENGTH = MAGIC.length + 8 + 4;
+const SEGMENT_HEADER_LENGTH = 1 + 8 + 8 + 8 + NONCE_LENGTH;
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+export const MAX_STASH_CONTENT_LENGTH = 100 * 1024 * 1024;
+export const MAX_SEALED_PACKAGE_OVERHEAD =
+  PACKAGE_HEADER_LENGTH + 3 * SEGMENT_HEADER_LENGTH + 2 * TAG_LENGTH;
+
+const encoder = new TextEncoder();
+
+interface PublicSegment {
+  visibility: 'public';
+  offset: number;
+  length: number;
+  bytes: Uint8Array;
+}
+
+interface EncryptedSegment {
+  visibility: 'encrypted';
+  offset: number;
+  length: number;
+  nonce: Uint8Array;
+  ciphertext: Uint8Array;
+}
+
+type StashPackageSegment = PublicSegment | EncryptedSegment;
+
+export interface StashPackage {
+  version: typeof STASH_BLOB_FORMAT;
+  contentLength: number;
+  segments: StashPackageSegment[];
+}
+
+export interface PreviewContentRange {
+  offset: number;
+  bytes: Uint8Array | ArrayBuffer;
+}
+
+export interface SealedStashPackage {
+  blob: Uint8Array;
+  blobSha256: string;
+  secretKey: string;
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+
+  return result;
+}
+
+function uint32Bytes(value: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, value, false);
+  return bytes;
+}
+
+function uint64Bytes(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Package offsets must be safe non-negative integers');
+  }
+
+  const bytes = new Uint8Array(8);
+  new DataView(bytes.buffer).setBigUint64(0, BigInt(value), false);
+  return bytes;
+}
+
+function readUint64(view: DataView, offset: number): number {
+  const value = view.getBigUint64(offset, false);
+  if (value > MAX_SAFE_BIGINT) {
+    throw new Error('Package integer is too large');
+  }
+  return Number(value);
+}
+
+function segmentAad(contentLength: number, offset: number, length: number): Uint8Array {
+  return encoder.encode(`${STASH_BLOB_FORMAT}:${contentLength}:${offset}:${length}`);
+}
+
+function encryptedSegment(
+  content: Uint8Array,
+  contentLength: number,
+  offset: number,
+  key: Uint8Array
+): EncryptedSegment | undefined {
+  if (content.length === 0) return undefined;
+
+  const nonce = randomBytes(NONCE_LENGTH);
+  const cipher = xchacha20poly1305(key, nonce, segmentAad(contentLength, offset, content.length));
+  return {
+    visibility: 'encrypted',
+    offset,
+    length: content.length,
+    nonce,
+    ciphertext: cipher.encrypt(content),
+  };
+}
+
+function encodeSegment(segment: StashPackageSegment): Uint8Array {
+  const encrypted = segment.visibility === 'encrypted';
+  const payload = encrypted ? segment.ciphertext : segment.bytes;
+  const nonce = encrypted ? segment.nonce : new Uint8Array(NONCE_LENGTH);
+
+  return concat([
+    new Uint8Array([encrypted ? 0 : 1]),
+    uint64Bytes(segment.offset),
+    uint64Bytes(segment.length),
+    uint64Bytes(payload.length),
+    nonce,
+    payload,
+  ]);
+}
+
+function serializePackage(contentLength: number, segments: StashPackageSegment[]): Uint8Array {
+  return concat([
+    MAGIC,
+    uint64Bytes(contentLength),
+    uint32Bytes(segments.length),
+    ...segments.map(encodeSegment),
+  ]);
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function validatePreviewRange(
+  content: Uint8Array,
+  previewRange: PreviewContentRange | undefined
+): { offset: number; bytes: Uint8Array } | undefined {
+  if (!previewRange) return undefined;
+
+  const bytes = toBytes(previewRange.bytes);
+  if (
+    !Number.isSafeInteger(previewRange.offset) ||
+    previewRange.offset < 0 ||
+    bytes.length === 0 ||
+    previewRange.offset + bytes.length > content.length ||
+    !bytesEqual(content.slice(previewRange.offset, previewRange.offset + bytes.length), bytes)
+  ) {
+    throw new Error('Public package range must match the file');
+  }
+
+  return { offset: previewRange.offset, bytes };
+}
+
+export function createSealedStashPackage(
+  content: Uint8Array | ArrayBuffer,
+  previewRange?: PreviewContentRange
+): SealedStashPackage {
+  const contentBytes = toBytes(content);
+  if (contentBytes.length === 0 || contentBytes.length > MAX_STASH_CONTENT_LENGTH) {
+    throw new Error('Sealed stash file size is outside the supported range');
+  }
+
+  const publicRange = validatePreviewRange(contentBytes, previewRange);
+  const key = generateKey();
+  const segments: StashPackageSegment[] = [];
+
+  if (publicRange) {
+    const prefix = encryptedSegment(
+      contentBytes.slice(0, publicRange.offset),
+      contentBytes.length,
+      0,
+      key
+    );
+    if (prefix) segments.push(prefix);
+
+    segments.push({
+      visibility: 'public',
+      offset: publicRange.offset,
+      length: publicRange.bytes.length,
+      bytes: publicRange.bytes,
+    });
+
+    const suffixOffset = publicRange.offset + publicRange.bytes.length;
+    const suffix = encryptedSegment(
+      contentBytes.slice(suffixOffset),
+      contentBytes.length,
+      suffixOffset,
+      key
+    );
+    if (suffix) segments.push(suffix);
+  } else {
+    const segment = encryptedSegment(contentBytes, contentBytes.length, 0, key);
+    if (segment) segments.push(segment);
+  }
+
+  const blob = serializePackage(contentBytes.length, segments);
+  return {
+    blob,
+    blobSha256: sha256(blob),
+    secretKey: `${KEY_PREFIX}${toBase64(key)}`,
+  };
+}
+
+export function isSealedStashSecretKey(secretKey: string): boolean {
+  return secretKey.startsWith(KEY_PREFIX);
+}
+
+export function parseSealedStashPackage(blob: Uint8Array | ArrayBuffer): StashPackage {
+  const bytes = toBytes(blob);
+  if (bytes.length < PACKAGE_HEADER_LENGTH || !bytesEqual(bytes.slice(0, MAGIC.length), MAGIC)) {
+    throw new Error('Invalid sealed stash package header');
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const contentLength = readUint64(view, MAGIC.length);
+  const segmentCount = view.getUint32(MAGIC.length + 8, false);
+  if (
+    contentLength === 0 ||
+    contentLength > MAX_STASH_CONTENT_LENGTH ||
+    segmentCount === 0 ||
+    segmentCount > 3
+  ) {
+    throw new Error('Invalid sealed stash package shape');
+  }
+
+  const segments: StashPackageSegment[] = [];
+  let cursor = PACKAGE_HEADER_LENGTH;
+  let expectedOffset = 0;
+  let publicSegments = 0;
+
+  for (let index = 0; index < segmentCount; index += 1) {
+    if (cursor + SEGMENT_HEADER_LENGTH > bytes.length) {
+      throw new Error('Truncated sealed stash package');
+    }
+
+    const kind = view.getUint8(cursor);
+    const offset = readUint64(view, cursor + 1);
+    const length = readUint64(view, cursor + 9);
+    const payloadLength = readUint64(view, cursor + 17);
+    const nonce = bytes.slice(cursor + 25, cursor + SEGMENT_HEADER_LENGTH);
+    cursor += SEGMENT_HEADER_LENGTH;
+
+    if (
+      (kind !== 0 && kind !== 1) ||
+      length === 0 ||
+      offset !== expectedOffset ||
+      offset + length > contentLength ||
+      cursor + payloadLength > bytes.length
+    ) {
+      throw new Error('Invalid sealed stash segment');
+    }
+
+    const payload = bytes.slice(cursor, cursor + payloadLength);
+    cursor += payloadLength;
+
+    if (kind === 0) {
+      if (payloadLength !== length + TAG_LENGTH) {
+        throw new Error('Invalid encrypted segment length');
+      }
+      segments.push({ visibility: 'encrypted', offset, length, nonce, ciphertext: payload });
+    } else {
+      if (payloadLength !== length || nonce.some((value) => value !== 0)) {
+        throw new Error('Invalid public segment');
+      }
+      publicSegments += 1;
+      segments.push({ visibility: 'public', offset, length, bytes: payload });
+    }
+
+    expectedOffset += length;
+  }
+
+  if (cursor !== bytes.length || expectedOffset !== contentLength || publicSegments > 1) {
+    throw new Error('Invalid sealed stash package coverage');
+  }
+
+  return { version: STASH_BLOB_FORMAT, contentLength, segments };
+}
+
+export function verifySealedStashPackage(
+  blob: Uint8Array | ArrayBuffer,
+  expectedSha256: string,
+  previewRange?: PreviewContentRange
+): boolean {
+  try {
+    const bytes = toBytes(blob);
+    if (sha256(bytes) !== expectedSha256) return false;
+
+    const stashPackage = parseSealedStashPackage(bytes);
+    const publicSegments = stashPackage.segments.filter(
+      (segment): segment is PublicSegment => segment.visibility === 'public'
+    );
+
+    if (!previewRange) return publicSegments.length === 0;
+
+    const previewBytes = toBytes(previewRange.bytes);
+    return (
+      publicSegments.length === 1 &&
+      publicSegments[0].offset === previewRange.offset &&
+      bytesEqual(publicSegments[0].bytes, previewBytes)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function decryptSealedStashPackage(
+  blob: Uint8Array | ArrayBuffer,
+  secretKey: string,
+  expectedSha256?: string
+): ArrayBuffer {
+  const bytes = toBytes(blob);
+  if (expectedSha256 && sha256(bytes) !== expectedSha256) {
+    throw new Error('Sealed stash package hash mismatch');
+  }
+  if (!isSealedStashSecretKey(secretKey)) {
+    throw new Error('Invalid sealed stash key format');
+  }
+
+  const key = fromBase64(secretKey.slice(KEY_PREFIX.length));
+  if (key.length !== 32) {
+    throw new Error('Invalid sealed stash key length');
+  }
+
+  const stashPackage = parseSealedStashPackage(bytes);
+  const plaintext = new Uint8Array(stashPackage.contentLength);
+
+  for (const segment of stashPackage.segments) {
+    if (segment.visibility === 'public') {
+      plaintext.set(segment.bytes, segment.offset);
+      continue;
+    }
+
+    const cipher = xchacha20poly1305(
+      key,
+      segment.nonce,
+      segmentAad(stashPackage.contentLength, segment.offset, segment.length)
+    );
+    plaintext.set(cipher.decrypt(segment.ciphertext), segment.offset);
+  }
+
+  return plaintext.buffer;
+}

--- a/client/src/lib/stashPackage.ts
+++ b/client/src/lib/stashPackage.ts
@@ -1,5 +1,6 @@
 import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
 import { fromBase64, generateKey, sha256, toBase64 } from './crypto';
+import { concat, randomBytes, toBytes, uint32Bytes, uint64Bytes } from './bytes';
 
 export const STASH_BLOB_FORMAT = 'stashu-selective-v1' as const;
 
@@ -48,45 +49,6 @@ export interface SealedStashPackage {
   blob: Uint8Array;
   blobSha256: string;
   secretKey: string;
-}
-
-function randomBytes(length: number): Uint8Array {
-  const bytes = new Uint8Array(length);
-  crypto.getRandomValues(bytes);
-  return bytes;
-}
-
-function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
-  return data instanceof Uint8Array ? data : new Uint8Array(data);
-}
-
-function concat(parts: Uint8Array[]): Uint8Array {
-  const length = parts.reduce((total, part) => total + part.length, 0);
-  const result = new Uint8Array(length);
-  let offset = 0;
-
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.length;
-  }
-
-  return result;
-}
-
-function uint32Bytes(value: number): Uint8Array {
-  const bytes = new Uint8Array(4);
-  new DataView(bytes.buffer).setUint32(0, value, false);
-  return bytes;
-}
-
-function uint64Bytes(value: number): Uint8Array {
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw new Error('Package offsets must be safe non-negative integers');
-  }
-
-  const bytes = new Uint8Array(8);
-  new DataView(bytes.buffer).setBigUint64(0, BigInt(value), false);
-  return bytes;
 }
 
 function readUint64(view: DataView, offset: number): number {

--- a/client/src/lib/stashProof.test.ts
+++ b/client/src/lib/stashProof.test.ts
@@ -5,6 +5,7 @@ import {
   verifyPreviewInclusion,
   verifyUnlockedFile,
 } from './stashProof.js';
+import { decryptFile, encryptFile } from './crypto.js';
 
 const encoder = new TextEncoder();
 
@@ -172,5 +173,34 @@ describe('stash proof commitments', () => {
     const { proof } = createStashProof(bytes('public preview'), bytes('hidden file'));
 
     expect(verifyUnlockedFile(bytes('hidden file'), proof, {})).toBe(false);
+  });
+
+  it('documents the v1 boundary: a detached ciphertext mismatch is caught only after unlock', async () => {
+    const promised = bytes('public peek\npromised hidden text');
+    const delivered = bytes('different file encrypted by a custom seller');
+    const preview = bytes('public peek');
+    const { proof, secret } = createStashProof(bytes('preview payload'), promised, {
+      previewContent: preview,
+    });
+    const { ciphertext, nonce, key } = await encryptFile(delivered.buffer as ArrayBuffer);
+    const decrypted = await decryptFile(ciphertext, key, nonce);
+
+    expect(verifyPreviewInclusion(preview, proof)).toBe(true);
+    expect(verifyUnlockedFile(decrypted, proof, secret)).toBe(false);
+  });
+
+  it('binds v2 proofs to a sealed blob hash', () => {
+    const sealedBlobSha256 = 'a'.repeat(64);
+    const { proof } = createStashProof(bytes('preview payload'), bytes('public peek\nhidden'), {
+      previewContent: bytes('public peek'),
+      sealedBlobSha256,
+    });
+
+    expect(proof.version).toBe('stashu-preview-v2');
+    expect(proof.sealedBlobSha256).toBe(sealedBlobSha256);
+    expect(verifyPreview(bytes('preview payload'), proof)).toBe(true);
+    expect(
+      verifyPreview(bytes('preview payload'), { ...proof, sealedBlobSha256: 'b'.repeat(64) })
+    ).toBe(false);
   });
 });

--- a/client/src/lib/stashProof.ts
+++ b/client/src/lib/stashProof.ts
@@ -1,6 +1,7 @@
 import { bytesToHex, sha256 } from './crypto.js';
 
 export const STASH_PROOF_VERSION = 'stashu-preview-v1' as const;
+export const SEALED_STASH_PROOF_VERSION = 'stashu-preview-v2' as const;
 export const DEFAULT_CONTENT_CHUNK_SIZE = 64 * 1024;
 
 const SALT_LENGTH = 32;
@@ -20,12 +21,13 @@ export interface PreviewInclusionProof {
 }
 
 export interface StashProof {
-  version: typeof STASH_PROOF_VERSION;
+  version: typeof STASH_PROOF_VERSION | typeof SEALED_STASH_PROOF_VERSION;
   root: string;
   previewHash: string;
   contentMerkleRoot: string;
   contentLength: number;
   chunkSize: number;
+  sealedBlobSha256?: string;
   previewInclusion?: PreviewInclusionProof;
 }
 
@@ -42,6 +44,7 @@ export interface CreateStashProofOptions {
   salt?: Uint8Array;
   previewContent?: Uint8Array | ArrayBuffer | PreviewContentRange;
   chunkSize?: number;
+  sealedBlobSha256?: string;
 }
 
 export interface PreviewContentRange {
@@ -121,20 +124,29 @@ function uint64Bytes(value: number): Uint8Array {
   return bytes;
 }
 
-function previewLeaf(previewPayload: Uint8Array): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:preview`, [previewPayload]);
+function previewLeaf(version: StashProof['version'], previewPayload: Uint8Array): string {
+  return taggedHash(`${version}:preview`, [previewPayload]);
 }
 
-function publicContentLeaf(offset: number, content: Uint8Array): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:content-leaf-public`, [
+function publicContentLeaf(
+  version: StashProof['version'],
+  offset: number,
+  content: Uint8Array
+): string {
+  return taggedHash(`${version}:content-leaf-public`, [
     uint64Bytes(offset),
     uint32Bytes(content.length),
     content,
   ]);
 }
 
-function privateContentLeaf(offset: number, content: Uint8Array, salt: Uint8Array): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:content-leaf-private`, [
+function privateContentLeaf(
+  version: StashProof['version'],
+  offset: number,
+  content: Uint8Array,
+  salt: Uint8Array
+): string {
+  return taggedHash(`${version}:content-leaf-private`, [
     uint64Bytes(offset),
     uint32Bytes(content.length),
     salt,
@@ -142,18 +154,25 @@ function privateContentLeaf(offset: number, content: Uint8Array, salt: Uint8Arra
   ]);
 }
 
-function merkleParent(left: string, right: string): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:merkle-parent`, [
-    hashToBytes(left),
-    hashToBytes(right),
-  ]);
+function merkleParent(version: StashProof['version'], left: string, right: string): string {
+  return taggedHash(`${version}:merkle-parent`, [hashToBytes(left), hashToBytes(right)]);
 }
 
-function rootHash(previewHash: string, contentMerkleRoot: string): string {
-  return taggedHash(`${STASH_PROOF_VERSION}:root`, [
-    hashToBytes(previewHash),
-    hashToBytes(contentMerkleRoot),
-  ]);
+function rootHash(
+  version: StashProof['version'],
+  previewHash: string,
+  contentMerkleRoot: string,
+  sealedBlobSha256?: string
+): string {
+  const parts = [hashToBytes(previewHash), hashToBytes(contentMerkleRoot)];
+  if (version === SEALED_STASH_PROOF_VERSION) {
+    if (!sealedBlobSha256 || !isHash(sealedBlobSha256)) {
+      throw new Error('Sealed stash proof requires a valid blob hash');
+    }
+    parts.push(hashToBytes(sealedBlobSha256));
+  }
+
+  return taggedHash(`${version}:root`, parts);
 }
 
 function validateChunkSize(chunkSize: number): void {
@@ -200,6 +219,7 @@ function normalizePreviewRange(
 }
 
 function contentLeaves(
+  version: StashProof['version'],
   content: Uint8Array,
   salt: Uint8Array,
   previewRange: { offset: number; bytes: Uint8Array } | undefined,
@@ -212,7 +232,7 @@ function contentLeaves(
     let offset = start;
     while (offset < end) {
       const nextOffset = Math.min(offset + chunkSize, end);
-      leaves.push(privateContentLeaf(offset, content.slice(offset, nextOffset), salt));
+      leaves.push(privateContentLeaf(version, offset, content.slice(offset, nextOffset), salt));
       offset = nextOffset;
     }
   };
@@ -220,20 +240,20 @@ function contentLeaves(
   if (previewRange) {
     addPrivateLeaves(0, previewRange.offset);
     previewLeafIndex = leaves.length;
-    leaves.push(publicContentLeaf(previewRange.offset, previewRange.bytes));
+    leaves.push(publicContentLeaf(version, previewRange.offset, previewRange.bytes));
     addPrivateLeaves(previewRange.offset + previewRange.bytes.length, content.length);
   } else {
     addPrivateLeaves(0, content.length);
   }
 
   if (leaves.length === 0) {
-    leaves.push(privateContentLeaf(0, new Uint8Array(), salt));
+    leaves.push(privateContentLeaf(version, 0, new Uint8Array(), salt));
   }
 
   return { leaves, previewLeafIndex };
 }
 
-function merkleRoot(leaves: string[]): string {
+function merkleRoot(version: StashProof['version'], leaves: string[]): string {
   let level = leaves;
 
   while (level.length > 1) {
@@ -243,7 +263,7 @@ function merkleRoot(leaves: string[]): string {
       if (i + 1 >= level.length) {
         nextLevel.push(level[i]);
       } else {
-        nextLevel.push(merkleParent(level[i], level[i + 1]));
+        nextLevel.push(merkleParent(version, level[i], level[i + 1]));
       }
     }
 
@@ -253,7 +273,11 @@ function merkleRoot(leaves: string[]): string {
   return level[0];
 }
 
-function merklePath(leaves: string[], leafIndex: number): MerkleProofStep[] {
+function merklePath(
+  version: StashProof['version'],
+  leaves: string[],
+  leafIndex: number
+): MerkleProofStep[] {
   const path: MerkleProofStep[] = [];
   let level = leaves;
   let index = leafIndex;
@@ -274,7 +298,7 @@ function merklePath(leaves: string[], leafIndex: number): MerkleProofStep[] {
       if (i + 1 >= level.length) {
         nextLevel.push(level[i]);
       } else {
-        nextLevel.push(merkleParent(level[i], level[i + 1]));
+        nextLevel.push(merkleParent(version, level[i], level[i + 1]));
       }
     }
 
@@ -285,12 +309,19 @@ function merklePath(leaves: string[], leafIndex: number): MerkleProofStep[] {
   return path;
 }
 
-function verifyMerklePath(leafHash: string, path: MerkleProofStep[], root: string): boolean {
+function verifyMerklePath(
+  version: StashProof['version'],
+  leafHash: string,
+  path: MerkleProofStep[],
+  root: string
+): boolean {
   let current = leafHash;
 
   for (const step of path) {
     current =
-      step.side === 'left' ? merkleParent(step.hash, current) : merkleParent(current, step.hash);
+      step.side === 'left'
+        ? merkleParent(version, step.hash, current)
+        : merkleParent(version, current, step.hash);
   }
 
   return current === root;
@@ -306,7 +337,7 @@ function isPreviewInclusionProof(value: unknown): value is PreviewInclusionProof
   return (
     Number.isSafeInteger(value.offset) &&
     (value.offset as number) >= 0 &&
-    Number.isInteger(value.length) &&
+    Number.isSafeInteger(value.length) &&
     (value.length as number) > 0 &&
     typeof value.leafHash === 'string' &&
     isHash(value.leafHash) &&
@@ -325,16 +356,20 @@ function isProofShape(proof: unknown): proof is StashProof {
   if (!isRecord(proof)) return false;
 
   return (
-    proof.version === STASH_PROOF_VERSION &&
+    (proof.version === STASH_PROOF_VERSION || proof.version === SEALED_STASH_PROOF_VERSION) &&
     typeof proof.previewHash === 'string' &&
     typeof proof.contentMerkleRoot === 'string' &&
     typeof proof.root === 'string' &&
-    Number.isInteger(proof.contentLength) &&
+    Number.isSafeInteger(proof.contentLength) &&
     (proof.contentLength as number) >= 0 &&
-    Number.isInteger(proof.chunkSize) &&
+    Number.isSafeInteger(proof.chunkSize) &&
     isHash(proof.previewHash) &&
     isHash(proof.contentMerkleRoot) &&
     isHash(proof.root) &&
+    ((proof.version === STASH_PROOF_VERSION && proof.sealedBlobSha256 === undefined) ||
+      (proof.version === SEALED_STASH_PROOF_VERSION &&
+        typeof proof.sealedBlobSha256 === 'string' &&
+        isHash(proof.sealedBlobSha256))) &&
     (proof.previewInclusion === undefined || isPreviewInclusionProof(proof.previewInclusion))
   );
 }
@@ -353,29 +388,40 @@ export function createStashProof(
   validateChunkSize(chunkSize);
 
   const contentBytes = toBytes(content);
+  const version = options.sealedBlobSha256 ? SEALED_STASH_PROOF_VERSION : STASH_PROOF_VERSION;
+  if (options.sealedBlobSha256 && !isHash(options.sealedBlobSha256)) {
+    throw new Error('Sealed blob SHA-256 must be 64 lowercase hex characters');
+  }
   const previewRange = normalizePreviewRange(contentBytes, options.previewContent);
-  const previewHash = previewLeaf(toBytes(previewPayload));
-  const { leaves, previewLeafIndex } = contentLeaves(contentBytes, salt, previewRange, chunkSize);
-  const contentMerkleRoot = merkleRoot(leaves);
+  const previewHash = previewLeaf(version, toBytes(previewPayload));
+  const { leaves, previewLeafIndex } = contentLeaves(
+    version,
+    contentBytes,
+    salt,
+    previewRange,
+    chunkSize
+  );
+  const contentMerkleRoot = merkleRoot(version, leaves);
   const previewInclusion =
     previewRange && previewLeafIndex !== undefined
       ? {
           offset: previewRange.offset,
           length: previewRange.bytes.length,
           leafHash: leaves[previewLeafIndex],
-          path: merklePath(leaves, previewLeafIndex),
+          path: merklePath(version, leaves, previewLeafIndex),
         }
       : undefined;
 
   return {
     proof: {
-      version: STASH_PROOF_VERSION,
+      version,
       previewHash,
       contentMerkleRoot,
       contentLength: contentBytes.length,
       chunkSize,
+      sealedBlobSha256: options.sealedBlobSha256,
       previewInclusion,
-      root: rootHash(previewHash, contentMerkleRoot),
+      root: rootHash(version, previewHash, contentMerkleRoot, options.sealedBlobSha256),
     },
     secret: {
       contentSalt: bytesToHex(salt),
@@ -386,10 +432,13 @@ export function createStashProof(
 export function verifyPreview(previewPayload: Uint8Array | ArrayBuffer, proof: unknown): boolean {
   if (!isProofShape(proof)) return false;
 
-  const previewHash = previewLeaf(toBytes(previewPayload));
+  const previewHash = previewLeaf(proof.version, toBytes(previewPayload));
   if (previewHash !== proof.previewHash) return false;
 
-  return rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root;
+  return (
+    rootHash(proof.version, proof.previewHash, proof.contentMerkleRoot, proof.sealedBlobSha256) ===
+    proof.root
+  );
 }
 
 export function verifyPreviewInclusion(
@@ -406,11 +455,17 @@ export function verifyPreviewInclusion(
     return false;
   }
 
-  const leafHash = publicContentLeaf(proof.previewInclusion.offset, previewBytes);
+  const leafHash = publicContentLeaf(proof.version, proof.previewInclusion.offset, previewBytes);
   return (
     leafHash === proof.previewInclusion.leafHash &&
-    verifyMerklePath(leafHash, proof.previewInclusion.path, proof.contentMerkleRoot) &&
-    rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root
+    verifyMerklePath(
+      proof.version,
+      leafHash,
+      proof.previewInclusion.path,
+      proof.contentMerkleRoot
+    ) &&
+    rootHash(proof.version, proof.previewHash, proof.contentMerkleRoot, proof.sealedBlobSha256) ===
+      proof.root
   );
 }
 
@@ -443,8 +498,14 @@ export function verifyUnlockedFile(
         ),
       }
     : undefined;
-  const { leaves } = contentLeaves(contentBytes, salt, previewRange, proof.chunkSize);
-  const contentMerkleRoot = merkleRoot(leaves);
+  const { leaves } = contentLeaves(
+    proof.version,
+    contentBytes,
+    salt,
+    previewRange,
+    proof.chunkSize
+  );
+  const contentMerkleRoot = merkleRoot(proof.version, leaves);
   if (contentMerkleRoot !== proof.contentMerkleRoot) return false;
 
   if (proof.previewInclusion) {
@@ -453,7 +514,10 @@ export function verifyUnlockedFile(
     }
   }
 
-  return rootHash(proof.previewHash, proof.contentMerkleRoot) === proof.root;
+  return (
+    rootHash(proof.version, proof.previewHash, proof.contentMerkleRoot, proof.sealedBlobSha256) ===
+    proof.root
+  );
 }
 
 function validateChunkSizeForVerify(chunkSize: number): boolean {

--- a/client/src/lib/stashProof.ts
+++ b/client/src/lib/stashProof.ts
@@ -1,4 +1,5 @@
 import { bytesToHex, sha256 } from './crypto.js';
+import { concat, randomBytes, toBytes, uint32Bytes, uint64Bytes } from './bytes.js';
 
 export const STASH_PROOF_VERSION = 'stashu-preview-v1' as const;
 export const SEALED_STASH_PROOF_VERSION = 'stashu-preview-v2' as const;
@@ -52,16 +53,6 @@ export interface PreviewContentRange {
   bytes: Uint8Array | ArrayBuffer;
 }
 
-function randomBytes(length: number): Uint8Array {
-  const bytes = new Uint8Array(length);
-  crypto.getRandomValues(bytes);
-  return bytes;
-}
-
-function toBytes(data: Uint8Array | ArrayBuffer): Uint8Array {
-  return data instanceof Uint8Array ? data : new Uint8Array(data);
-}
-
 function frame(part: Uint8Array): Uint8Array {
   if (part.length > MAX_FRAME_LENGTH) {
     throw new Error('Proof frame is too large');
@@ -71,19 +62,6 @@ function frame(part: Uint8Array): Uint8Array {
   new DataView(framed.buffer).setUint32(0, part.length, false);
   framed.set(part, 4);
   return framed;
-}
-
-function concat(parts: Uint8Array[]): Uint8Array {
-  const length = parts.reduce((total, part) => total + part.length, 0);
-  const result = new Uint8Array(length);
-  let offset = 0;
-
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.length;
-  }
-
-  return result;
 }
 
 function taggedHash(tag: string, parts: Uint8Array[]): string {
@@ -103,24 +81,6 @@ function hashToBytes(hash: string): Uint8Array {
   for (let i = 0; i < bytes.length; i++) {
     bytes[i] = Number.parseInt(hash.slice(i * 2, i * 2 + 2), 16);
   }
-  return bytes;
-}
-
-function uint32Bytes(value: number): Uint8Array {
-  const bytes = new Uint8Array(4);
-  new DataView(bytes.buffer).setUint32(0, value, false);
-  return bytes;
-}
-
-function uint64Bytes(value: number): Uint8Array {
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw new Error('Proof offset must be a safe non-negative integer');
-  }
-
-  const bytes = new Uint8Array(8);
-  const view = new DataView(bytes.buffer);
-  view.setUint32(0, Math.floor(value / 0x100000000), false);
-  view.setUint32(4, value >>> 0, false);
   return bytes;
 }
 

--- a/client/src/lib/useStash.ts
+++ b/client/src/lib/useStash.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { encryptFile, readFileAsArrayBuffer, toBase64 } from './crypto';
+import { readFileAsArrayBuffer } from './crypto';
 import { uploadToBlossom, getBlossomServer, mirrorToBackupServers } from './blossom';
 import { getPublicKey } from './nostr';
 import { createStash } from './api';
@@ -11,6 +11,7 @@ import {
   type TextLineLimit,
 } from './generatedPreview';
 import { createStashProof } from './stashProof';
+import { createSealedStashPackage, STASH_BLOB_FORMAT } from './stashPackage';
 
 export type StashStatus = 'idle' | 'encrypting' | 'uploading' | 'creating' | 'done' | 'error';
 
@@ -77,20 +78,27 @@ export function useStash() {
               bytes: decodeGeneratedPreviewBytes(generatedPreview),
             }
           : undefined;
+      const sealedPackage = createSealedStashPackage(fileBytes, previewContent);
       const { proof: previewProof, secret: previewSecret } = createStashProof(
         serializeGeneratedPreviewPayload(generatedPreview),
         fileBytes,
         {
           previewContent:
             previewContent && previewContent.bytes.length > 0 ? previewContent : undefined,
+          sealedBlobSha256: sealedPackage.blobSha256,
         }
       );
-      const { ciphertext, nonce, key } = await encryptFile(fileData);
-      const secretKey = `${toBase64(nonce)}:${toBase64(key)}`;
 
       setState((s) => ({ ...s, status: 'uploading', progress: 60 }));
       const selectedServer = getBlossomServer();
-      const uploadResult = await uploadToBlossom(ciphertext, file.type, selectedServer);
+      const uploadResult = await uploadToBlossom(
+        sealedPackage.blob,
+        'application/octet-stream',
+        selectedServer
+      );
+      if (uploadResult.sha256 !== sealedPackage.blobSha256) {
+        throw new Error('Uploaded sealed package hash did not match');
+      }
 
       // Mirror to backup servers for redundancy (fire-and-forget)
       mirrorToBackupServers(uploadResult.sha256, uploadResult.url, selectedServer);
@@ -99,7 +107,8 @@ export function useStash() {
       const stashResult = await createStash({
         blobUrl: uploadResult.url,
         blobSha256: uploadResult.sha256,
-        secretKey,
+        secretKey: sealedPackage.secretKey,
+        blobFormat: STASH_BLOB_FORMAT,
         sellerPubkey: pubkey,
         priceSats: options.priceSats,
         title: options.title,

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -1,8 +1,14 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { getStashInfo, unlockStash, claimStash } from './api';
 import { decryptFile, fromBase64 } from './crypto';
 import { fetchFromBlossomWithFallback } from './blossom';
-import { verifyUnlockedStashFile } from './verifiedPreview';
+import { verifySealedStashPackageBundle, verifyUnlockedStashFile } from './verifiedPreview';
+import {
+  decryptSealedStashPackage,
+  isSealedStashSecretKey,
+  MAX_SEALED_PACKAGE_OVERHEAD,
+  STASH_BLOB_FORMAT,
+} from './stashPackage';
 import type { StashProofSecret, StashPublicInfo } from '../../../shared/types';
 
 export type UnlockStatus =
@@ -26,6 +32,7 @@ export interface UnlockState {
 }
 
 export function useUnlock(stashId: string) {
+  const sealedPackageRef = useRef<Uint8Array | null>(null);
   const [state, setState] = useState<UnlockState>({
     status: 'loading',
     stash: null,
@@ -47,16 +54,16 @@ export function useUnlock(stashId: string) {
     }) => {
       setState((s) => ({ ...s, status: 'decrypting', error: null }));
 
-      const ciphertext = await fetchFromBlossomWithFallback(data.blobUrl, data.blobSha256);
-
-      const [nonceB64, keyB64] = data.secretKey.split(':');
-      if (!nonceB64 || !keyB64) {
-        throw new Error('Invalid secret key format');
-      }
-      const nonce = fromBase64(nonceB64);
-      const key = fromBase64(keyB64);
-
-      const plaintext = await decryptFile(ciphertext, key, nonce);
+      const sealedBlob =
+        sealedPackageRef.current ??
+        (await fetchFromBlossomWithFallback(
+          data.blobUrl,
+          data.blobSha256,
+          state.stash ? state.stash.fileSize + MAX_SEALED_PACKAGE_OVERHEAD : undefined
+        ));
+      const plaintext = isSealedStashSecretKey(data.secretKey)
+        ? decryptSealedStashPackage(sealedBlob, data.secretKey, data.blobSha256)
+        : await decryptLegacyFile(sealedBlob, data.secretKey);
       if (
         state.stash?.previewProof &&
         !verifyUnlockedStashFile(state.stash, plaintext, data.previewSecret)
@@ -91,6 +98,21 @@ export function useUnlock(stashId: string) {
         blobSha256: null,
       }));
       const stash = await getStashInfo(stashId);
+      sealedPackageRef.current = null;
+      if (stash.blobFormat === STASH_BLOB_FORMAT && stash.generatedPreview?.kind === 'text-peek') {
+        if (!stash.sealedBlobUrl || !stash.blobSha256) {
+          throw new Error('Sealed stash package metadata is missing');
+        }
+        const sealedPackage = await fetchFromBlossomWithFallback(
+          stash.sealedBlobUrl,
+          stash.blobSha256,
+          stash.fileSize + MAX_SEALED_PACKAGE_OVERHEAD
+        );
+        if (!verifySealedStashPackageBundle(stash, sealedPackage)) {
+          throw new Error('Sealed stash package verification failed');
+        }
+        sealedPackageRef.current = sealedPackage;
+      }
       // If a claim token exists, go straight to 'claiming' to avoid flashing payment UI
       const hasClaimToken = !!localStorage.getItem(`stashu-claim-${stashId}`);
       setState((s) => ({ ...s, status: hasClaimToken ? 'claiming' : 'ready', stash }));
@@ -214,6 +236,7 @@ export function useUnlock(stashId: string) {
     if (state.downloadUrl) {
       URL.revokeObjectURL(state.downloadUrl);
     }
+    sealedPackageRef.current = null;
     setState({
       status: 'loading',
       stash: null,
@@ -235,4 +258,13 @@ export function useUnlock(stashId: string) {
     payAgain,
     reset,
   };
+}
+
+async function decryptLegacyFile(ciphertext: Uint8Array, secretKey: string): Promise<ArrayBuffer> {
+  const [nonceB64, keyB64] = secretKey.split(':');
+  if (!nonceB64 || !keyB64) {
+    throw new Error('Invalid secret key format');
+  }
+
+  return decryptFile(ciphertext, fromBase64(keyB64), fromBase64(nonceB64));
 }

--- a/client/src/lib/useUnlock.ts
+++ b/client/src/lib/useUnlock.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { getStashInfo, unlockStash, claimStash } from './api';
 import { decryptFile, fromBase64 } from './crypto';
 import { fetchFromBlossomWithFallback } from './blossom';
@@ -31,8 +31,11 @@ export interface UnlockState {
   claimExpiresAt: number | null;
 }
 
+// Hash-keyed so the pre-payment download survives remounts and can never be
+// served for a different blob. Single entry keeps at most one package in memory.
+let cachedSealedPackage: { sha256: string; blob: Uint8Array } | null = null;
+
 export function useUnlock(stashId: string) {
-  const sealedPackageRef = useRef<Uint8Array | null>(null);
   const [state, setState] = useState<UnlockState>({
     status: 'loading',
     stash: null,
@@ -55,7 +58,9 @@ export function useUnlock(stashId: string) {
       setState((s) => ({ ...s, status: 'decrypting', error: null }));
 
       const sealedBlob =
-        sealedPackageRef.current ??
+        (data.blobSha256 && cachedSealedPackage?.sha256 === data.blobSha256
+          ? cachedSealedPackage.blob
+          : null) ??
         (await fetchFromBlossomWithFallback(
           data.blobUrl,
           data.blobSha256,
@@ -98,7 +103,7 @@ export function useUnlock(stashId: string) {
         blobSha256: null,
       }));
       const stash = await getStashInfo(stashId);
-      sealedPackageRef.current = null;
+      cachedSealedPackage = null;
       if (stash.blobFormat === STASH_BLOB_FORMAT && stash.generatedPreview?.kind === 'text-peek') {
         if (!stash.sealedBlobUrl || !stash.blobSha256) {
           throw new Error('Sealed stash package metadata is missing');
@@ -111,7 +116,7 @@ export function useUnlock(stashId: string) {
         if (!verifySealedStashPackageBundle(stash, sealedPackage)) {
           throw new Error('Sealed stash package verification failed');
         }
-        sealedPackageRef.current = sealedPackage;
+        cachedSealedPackage = { sha256: stash.blobSha256, blob: sealedPackage };
       }
       // If a claim token exists, go straight to 'claiming' to avoid flashing payment UI
       const hasClaimToken = !!localStorage.getItem(`stashu-claim-${stashId}`);
@@ -236,7 +241,7 @@ export function useUnlock(stashId: string) {
     if (state.downloadUrl) {
       URL.revokeObjectURL(state.downloadUrl);
     }
-    sealedPackageRef.current = null;
+    cachedSealedPackage = null;
     setState({
       status: 'loading',
       stash: null,

--- a/client/src/lib/verifiedPreview.test.ts
+++ b/client/src/lib/verifiedPreview.test.ts
@@ -8,8 +8,10 @@ import { createStashProof } from './stashProof.js';
 import {
   decodeTextPreview,
   verifyGeneratedPreviewBundle,
+  verifySealedStashPackageBundle,
   verifyUnlockedStashFile,
 } from './verifiedPreview.js';
+import { createSealedStashPackage, STASH_BLOB_FORMAT } from './stashPackage.js';
 
 const encoder = new TextEncoder();
 
@@ -141,5 +143,78 @@ describe('verified preview helpers', () => {
     );
 
     expect(decodeTextPreview(preview)).toBe('he');
+  });
+
+  it('verifies that a v2 public peek is a literal segment of the fetched sealed package', () => {
+    const content = bytes('intro\nsafe excerpt\npaid-only ending');
+    const offset = bytes('intro\n').length;
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: content.length,
+        content,
+      },
+      {
+        mode: 'excerpt',
+        excerpt: { offset, text: 'safe excerpt' },
+        maxPreviewRatio: 0.5,
+      }
+    );
+    const previewRange = { offset, bytes: decodeGeneratedPreviewBytes(preview) };
+    const sealed = createSealedStashPackage(content, previewRange);
+    const { proof } = createStashProof(serializeGeneratedPreviewPayload(preview), content, {
+      previewContent: previewRange,
+      sealedBlobSha256: sealed.blobSha256,
+    });
+
+    expect(
+      verifySealedStashPackageBundle(
+        {
+          blobFormat: STASH_BLOB_FORMAT,
+          blobSha256: sealed.blobSha256,
+          generatedPreview: preview,
+          previewProof: proof,
+        },
+        sealed.blob
+      )
+    ).toBe(true);
+  });
+
+  it('rejects a swapped v2 package before payment even when the public text is identical', () => {
+    const promised = bytes('same excerpt\npromised hidden');
+    const swapped = bytes('same excerpt\nswapped hidden!');
+    const preview = generatePreviewFromBytes(
+      {
+        fileName: 'prompt.md',
+        fileType: 'text/markdown',
+        fileSize: promised.length,
+        content: promised,
+      },
+      {
+        mode: 'excerpt',
+        excerpt: { offset: 0, text: 'same excerpt' },
+        maxPreviewRatio: 0.5,
+      }
+    );
+    const previewRange = { offset: 0, bytes: decodeGeneratedPreviewBytes(preview) };
+    const promisedPackage = createSealedStashPackage(promised, previewRange);
+    const swappedPackage = createSealedStashPackage(swapped, previewRange);
+    const { proof } = createStashProof(serializeGeneratedPreviewPayload(preview), promised, {
+      previewContent: previewRange,
+      sealedBlobSha256: promisedPackage.blobSha256,
+    });
+
+    expect(
+      verifySealedStashPackageBundle(
+        {
+          blobFormat: STASH_BLOB_FORMAT,
+          blobSha256: promisedPackage.blobSha256,
+          generatedPreview: preview,
+          previewProof: proof,
+        },
+        swappedPackage.blob
+      )
+    ).toBe(false);
   });
 });

--- a/client/src/lib/verifiedPreview.ts
+++ b/client/src/lib/verifiedPreview.ts
@@ -6,6 +6,12 @@ import type {
 } from '../../../shared/types';
 import { decodeGeneratedPreviewBytes, serializeGeneratedPreviewPayload } from './generatedPreview';
 import { verifyPreview, verifyPreviewInclusion, verifyUnlockedFile } from './stashProof';
+import {
+  STASH_BLOB_FORMAT,
+  parseSealedStashPackage,
+  verifySealedStashPackage,
+  type PreviewContentRange,
+} from './stashPackage';
 
 const decoder = new TextDecoder('utf-8', { fatal: true });
 
@@ -66,4 +72,43 @@ export function verifyUnlockedStashFile(
   if (!previewSecret) return false;
 
   return verifyUnlockedFile(content, stash.previewProof, previewSecret);
+}
+
+export function verifySealedStashPackageBundle(
+  stash: Pick<StashPublicInfo, 'blobFormat' | 'blobSha256' | 'generatedPreview' | 'previewProof'>,
+  blob: Uint8Array
+): boolean {
+  if (stash.blobFormat !== STASH_BLOB_FORMAT) return true;
+  if (
+    !stash.blobSha256 ||
+    !stash.previewProof ||
+    stash.previewProof.version !== 'stashu-preview-v2' ||
+    stash.previewProof.sealedBlobSha256 !== stash.blobSha256
+  ) {
+    return false;
+  }
+
+  if (
+    verifyGeneratedPreviewBundle(stash.generatedPreview, stash.previewProof).state !== 'verified'
+  ) {
+    return false;
+  }
+
+  let previewRange: PreviewContentRange | undefined;
+  if (stash.generatedPreview?.kind === 'text-peek') {
+    const metadata = stash.generatedPreview.metadata as { offset: number };
+    previewRange = {
+      offset: metadata.offset,
+      bytes: decodeGeneratedPreviewBytes(stash.generatedPreview),
+    };
+  }
+
+  try {
+    if (parseSealedStashPackage(blob).contentLength !== stash.previewProof.contentLength) {
+      return false;
+    }
+    return verifySealedStashPackage(blob, stash.blobSha256, previewRange);
+  } catch {
+    return false;
+  }
 }

--- a/server/.env.example
+++ b/server/.env.example
@@ -9,6 +9,9 @@ PORT=3000
 # Cashu Mint URL
 MINT_URL=https://mint.minibits.cash/Bitcoin
 
+# Abort an unresponsive Cashu mint request instead of leaving buyers waiting forever.
+CASHU_REQUEST_TIMEOUT_MS=10000
+
 # Database path (can be absolute or relative)
 # DB_PATH=./stashu.db
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,3 +15,6 @@ MINT_URL=https://mint.minibits.cash/Bitcoin
 # Token encryption key (64 hex chars = 32 bytes for XChaCha20-Poly1305)
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 TOKEN_ENCRYPTION_KEY=
+
+# Allow HTTP/local Blossom URLs only for intentional local development.
+# ALLOW_INSECURE_BLOSSOM_URLS=1

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -396,6 +396,14 @@ const currentVersion = (
         console.log('⏳ Added download_window_seconds column to stashes.');
       },
     },
+    {
+      version: 12,
+      name: 'add sealed blob format to stashes',
+      run: () => {
+        db.exec(`ALTER TABLE stashes ADD COLUMN blob_format TEXT DEFAULT NULL`);
+        console.log('Added blob_format column for sealed selective-reveal packages.');
+      },
+    },
   ];
 
   // Run pending migrations in a transaction

--- a/server/src/db/types.ts
+++ b/server/src/db/types.ts
@@ -20,6 +20,7 @@ export interface StashRow {
   description: string | null; // encrypted
   file_name: string; // encrypted
   file_size: number;
+  blob_format: string | null;
   preview_url: string | null;
   generated_preview_payload: string | null; // encrypted public metadata
   preview_proof: string | null; // encrypted public metadata

--- a/server/src/lib/cashu.test.ts
+++ b/server/src/lib/cashu.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for Cashu mint network resilience.
+ *
+ * Run with: npm test --workspace=server
+ */
+
+if (!process.env.TOKEN_ENCRYPTION_KEY) {
+  const { randomBytes } = await import('node:crypto');
+  process.env.TOKEN_ENCRYPTION_KEY = randomBytes(32).toString('hex');
+}
+process.env.DB_PATH = ':memory:';
+process.env.CASHU_REQUEST_TIMEOUT_MS = '25';
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { setGlobalRequestOptions } from '@cashu/cashu-ts';
+
+describe('Cashu mint request timeout', () => {
+  it('aborts a hanging mint request instead of waiting forever', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input, init) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        const abort = () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        };
+
+        if (signal?.aborted) {
+          abort();
+        } else {
+          signal?.addEventListener('abort', abort, { once: true });
+        }
+      })) as typeof fetch;
+
+    try {
+      const { createPaymentInvoice } = await import('./cashu.js');
+      const startedAt = Date.now();
+
+      await assert.rejects(createPaymentInvoice(5), /timed out after 25ms/i);
+      assert.ok(Date.now() - startedAt < 1_000, 'mint timeout should fail promptly');
+    } finally {
+      globalThis.fetch = originalFetch;
+      setGlobalRequestOptions({});
+    }
+  });
+});

--- a/server/src/lib/cashu.ts
+++ b/server/src/lib/cashu.ts
@@ -1,21 +1,42 @@
-import { Mint, Wallet, getDecodedToken, getEncodedTokenV4 } from '@cashu/cashu-ts';
+import {
+  Mint,
+  Wallet,
+  getDecodedToken,
+  getEncodedTokenV4,
+  setGlobalRequestOptions,
+} from '@cashu/cashu-ts';
 import type { Proof } from '@cashu/cashu-ts';
 import db from '../db/index.js';
 import { encrypt } from './encryption.js';
 
 // Cashu Mint URL — configurable via env for production
 const MINT_URL = process.env.MINT_URL || 'https://mint.minibits.cash/Bitcoin';
+const configuredTimeout = Number(process.env.CASHU_REQUEST_TIMEOUT_MS);
+const CASHU_REQUEST_TIMEOUT_MS =
+  Number.isInteger(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 10_000;
+
+setGlobalRequestOptions({ requestTimeout: CASHU_REQUEST_TIMEOUT_MS });
 
 let wallet: Wallet | null = null;
+let walletLoading: Promise<Wallet> | null = null;
 
 async function getWallet(): Promise<Wallet> {
-  if (!wallet) {
-    const mint = new Mint(MINT_URL);
-    wallet = new Wallet(mint);
-    // Load keys from mint
-    await wallet.loadMint();
+  if (wallet) return wallet;
+
+  if (!walletLoading) {
+    walletLoading = (async () => {
+      const mint = new Mint(MINT_URL);
+      const loadingWallet = new Wallet(mint);
+      // Cache only a fully initialized wallet so transient mint failures can recover.
+      await loadingWallet.loadMint();
+      wallet = loadingWallet;
+      return loadingWallet;
+    })().finally(() => {
+      walletLoading = null;
+    });
   }
-  return wallet;
+
+  return walletLoading;
 }
 
 export interface SwapResult {

--- a/server/src/lib/lnaddress.ts
+++ b/server/src/lib/lnaddress.ts
@@ -1,16 +1,14 @@
+import { isPrivateOrReservedHostname } from './publicUrl.js';
+
 /**
  * Validate that a domain is a public FQDN — not an IP, localhost, or reserved range.
  * Prevents SSRF via attacker-controlled Lightning addresses.
  */
 function isPublicDomain(domain: string): boolean {
-  // Block IP addresses (v4 and v6)
+  // Block IP addresses (v4 literals; v6 is caught by the shared hostname check)
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(domain)) return false;
-  if (domain.startsWith('[') || domain.includes(':')) return false;
 
-  // Block localhost and reserved TLDs
-  const blocked = ['localhost', 'local', 'internal', 'intranet', 'corp', 'home', 'lan'];
-  const lower = domain.toLowerCase();
-  if (blocked.some((b) => lower === b || lower.endsWith(`.${b}`))) return false;
+  if (isPrivateOrReservedHostname(domain)) return false;
 
   // Must have at least one dot (real domain)
   if (!domain.includes('.')) return false;

--- a/server/src/lib/publicUrl.ts
+++ b/server/src/lib/publicUrl.ts
@@ -1,0 +1,25 @@
+const RESERVED_TLDS = ['localhost', 'local', 'internal', 'intranet', 'corp', 'home', 'lan'];
+
+/**
+ * True when a hostname points at localhost, a reserved TLD, an IPv6 literal,
+ * or a private/reserved IPv4 range. Shared SSRF guard for outbound requests.
+ */
+export function isPrivateOrReservedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (lower.startsWith('[') || lower.includes(':')) return true;
+  if (RESERVED_TLDS.some((tld) => lower === tld || lower.endsWith(`.${tld}`))) return true;
+
+  const octets = lower.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+    return false;
+  }
+
+  return (
+    octets[0] === 0 ||
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
+}

--- a/server/src/lib/sealedBlob.ts
+++ b/server/src/lib/sealedBlob.ts
@@ -1,0 +1,23 @@
+import { decrypt } from './encryption.js';
+import type { StashRow } from '../db/types.js';
+import type { StashPublicInfo } from '../../../shared/types.js';
+
+export const SEALED_BLOB_FORMAT = 'stashu-selective-v1' as const;
+
+/**
+ * Map a stash row's sealed-package columns onto the public response shape.
+ * Legacy (non-sealed) stashes expose none of these fields.
+ */
+export function sealedStashFields(
+  row: Pick<StashRow, 'blob_format' | 'blob_url' | 'blob_sha256'>
+): Pick<StashPublicInfo, 'blobFormat' | 'sealedBlobUrl' | 'blobSha256'> {
+  if (row.blob_format !== SEALED_BLOB_FORMAT) {
+    return { blobFormat: undefined, sealedBlobUrl: undefined, blobSha256: undefined };
+  }
+
+  return {
+    blobFormat: SEALED_BLOB_FORMAT,
+    sealedBlobUrl: decrypt(row.blob_url),
+    blobSha256: row.blob_sha256 ?? undefined,
+  };
+}

--- a/server/src/routes/pay.ts
+++ b/server/src/routes/pay.ts
@@ -76,7 +76,10 @@ payRoutes.post('/:id/invoice', async (c) => {
     });
   } catch (error) {
     console.error('Error creating payment invoice:', error);
-    return c.json<APIResponse<never>>({ success: false, error: 'Failed to create invoice' }, 500);
+    return c.json<APIResponse<never>>(
+      { success: false, error: 'Cashu mint is unavailable. Please try again shortly.' },
+      503
+    );
   }
 });
 

--- a/server/src/routes/seller.ts
+++ b/server/src/routes/seller.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import db from '../db/index.js';
 import { decrypt } from '../lib/encryption.js';
+import { sealedStashFields } from '../lib/sealedBlob.js';
 import type {
   GeneratedPreviewPayload,
   StashProof,
@@ -11,7 +12,6 @@ import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const sellerRoutes = new Hono();
-const SEALED_BLOB_FORMAT = 'stashu-selective-v1';
 
 function parseStoredJson<T>(value: string | null): T | undefined {
   return value ? (JSON.parse(decrypt(value)) as T) : undefined;
@@ -90,10 +90,7 @@ sellerRoutes.get('/:pubkey', async (c) => {
       fileName: decrypt(row.file_name),
       fileSize: row.file_size,
       priceSats: row.price_sats,
-      blobFormat: row.blob_format === SEALED_BLOB_FORMAT ? SEALED_BLOB_FORMAT : undefined,
-      sealedBlobUrl: row.blob_format === SEALED_BLOB_FORMAT ? decrypt(row.blob_url) : undefined,
-      blobSha256:
-        row.blob_format === SEALED_BLOB_FORMAT ? (row.blob_sha256 ?? undefined) : undefined,
+      ...sealedStashFields(row),
       previewUrl: row.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(row.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(row.preview_proof),

--- a/server/src/routes/seller.ts
+++ b/server/src/routes/seller.ts
@@ -11,6 +11,7 @@ import { DEFAULT_DOWNLOAD_WINDOW_SECONDS } from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
 export const sellerRoutes = new Hono();
+const SEALED_BLOB_FORMAT = 'stashu-selective-v1';
 
 function parseStoredJson<T>(value: string | null): T | undefined {
   return value ? (JSON.parse(decrypt(value)) as T) : undefined;
@@ -56,8 +57,9 @@ sellerRoutes.get('/:pubkey', async (c) => {
     }
 
     const stmt = db.prepare(`
-      SELECT id, title, description, file_name, file_size, price_sats, preview_url,
-             generated_preview_payload, preview_proof, download_window_seconds, created_at
+      SELECT id, title, description, file_name, file_size, price_sats, blob_url, blob_sha256,
+             blob_format, preview_url, generated_preview_payload, preview_proof,
+             download_window_seconds, created_at
       FROM stashes
       WHERE seller_pubkey = ? AND show_in_storefront = 1
       ORDER BY created_at DESC
@@ -71,6 +73,9 @@ sellerRoutes.get('/:pubkey', async (c) => {
       | 'file_name'
       | 'file_size'
       | 'price_sats'
+      | 'blob_url'
+      | 'blob_sha256'
+      | 'blob_format'
       | 'preview_url'
       | 'generated_preview_payload'
       | 'preview_proof'
@@ -85,6 +90,10 @@ sellerRoutes.get('/:pubkey', async (c) => {
       fileName: decrypt(row.file_name),
       fileSize: row.file_size,
       priceSats: row.price_sats,
+      blobFormat: row.blob_format === SEALED_BLOB_FORMAT ? SEALED_BLOB_FORMAT : undefined,
+      sealedBlobUrl: row.blob_format === SEALED_BLOB_FORMAT ? decrypt(row.blob_url) : undefined,
+      blobSha256:
+        row.blob_format === SEALED_BLOB_FORMAT ? (row.blob_sha256 ?? undefined) : undefined,
       previewUrl: row.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(row.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(row.preview_proof),

--- a/server/src/routes/stash.test.ts
+++ b/server/src/routes/stash.test.ts
@@ -71,6 +71,22 @@ function validPreviewBundle(body = validBody()) {
   };
 }
 
+function validSealedPreviewBundle(body = validBody()) {
+  const bundle = validPreviewBundle(body);
+  const blobSha256 = 'e'.repeat(64);
+  return {
+    blobFormat: 'stashu-selective-v1',
+    blobSha256,
+    secretKey: `stashu-selective-v1:${'A'.repeat(43)}=`,
+    ...bundle,
+    previewProof: {
+      ...bundle.previewProof,
+      version: 'stashu-preview-v2',
+      sealedBlobSha256: blobSha256,
+    },
+  };
+}
+
 function base64Url(value: string) {
   return Buffer.from(value, 'utf8').toString('base64url');
 }
@@ -200,6 +216,85 @@ describe('POST /api/stash', () => {
     assert.deepEqual(JSON.parse(decrypt(row.preview_secret)), input.previewSecret);
   });
 
+  it('stores a sealed package only when its v2 proof binds the blob hash', async () => {
+    const input = { ...validBody(), ...validSealedPreviewBundle() };
+    const res = await createStash(input);
+    assert.equal(res.status, 201);
+    const { data } = await res.json();
+
+    const row = db.prepare('SELECT blob_format FROM stashes WHERE id = ?').get(data.id) as {
+      blob_format: string;
+    };
+    assert.equal(row.blob_format, 'stashu-selective-v1');
+  });
+
+  it('rejects a sealed package whose v2 proof binds a different blob hash', async () => {
+    const bundle = validSealedPreviewBundle();
+    const res = await createStash({
+      ...validBody(),
+      ...bundle,
+      blobSha256: 'f'.repeat(64),
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /hash/i);
+  });
+
+  it('rejects a sealed package without generated preview proof fields', async () => {
+    const res = await createStash({
+      ...validBody(),
+      blobFormat: 'stashu-selective-v1',
+      blobSha256: 'e'.repeat(64),
+      secretKey: `stashu-selective-v1:${'A'.repeat(43)}=`,
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /proof/i);
+  });
+
+  it('rejects a sealed package with a malformed package key', async () => {
+    const res = await createStash({
+      ...validBody(),
+      ...validSealedPreviewBundle(),
+      secretKey: 'not-a-sealed-key',
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /secretKey/i);
+  });
+
+  it('rejects a sealed package URL that could trigger a local-network fetch', async () => {
+    const res = await createStash({
+      ...validBody(),
+      ...validSealedPreviewBundle(),
+      blobUrl: 'http://127.0.0.1/private-service',
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /public HTTPS/i);
+  });
+
+  it('allows local sealed package URLs only with an explicit development opt-in', async () => {
+    const original = process.env.ALLOW_INSECURE_BLOSSOM_URLS;
+    process.env.ALLOW_INSECURE_BLOSSOM_URLS = '1';
+
+    try {
+      const res = await createStash({
+        ...validBody(),
+        ...validSealedPreviewBundle(),
+        blobUrl: 'http://127.0.0.1:3001/local-blob',
+      });
+
+      assert.equal(res.status, 201);
+    } finally {
+      if (original === undefined) {
+        delete process.env.ALLOW_INSECURE_BLOSSOM_URLS;
+      } else {
+        process.env.ALLOW_INSECURE_BLOSSOM_URLS = original;
+      }
+    }
+  });
+
   it('rejects partial preview bundles', async () => {
     const res = await createStash({
       ...validBody(),
@@ -222,7 +317,7 @@ describe('POST /api/stash', () => {
 
   it('requires inclusion proof for text previews', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -257,7 +352,7 @@ describe('POST /api/stash', () => {
 
   it('rejects text preview metadata that does not match preview bytes', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -302,7 +397,7 @@ describe('POST /api/stash', () => {
 
   it('rejects text previews above the declared preview ratio', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -347,7 +442,7 @@ describe('POST /api/stash', () => {
 
   it('rejects text preview ratios above the server cap', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -392,7 +487,7 @@ describe('POST /api/stash', () => {
 
   it('accepts text previews with matching inclusion proof metadata', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -434,9 +529,54 @@ describe('POST /api/stash', () => {
     assert.equal(res.status, 201);
   });
 
+  it('rejects fresh legacy v1 text previews that bypass sealed prepayment verification', async () => {
+    const body = validBody();
+    const bundle = validPreviewBundle(body);
+    const res = await createStash({
+      ...body,
+      ...bundle,
+      generatedPreview: {
+        version: 'stashu-generated-preview-v1',
+        kind: 'text-peek',
+        fileName: body.fileName,
+        fileType: 'text/plain',
+        fileSize: body.fileSize,
+        contentType: 'text/plain; charset=utf-8',
+        options: {
+          mode: 'auto',
+          lineLimit: 10,
+          maxBytes: 16_384,
+          maxChars: 4_000,
+          maxPreviewRatio: 0.15,
+        },
+        metadata: {
+          offset: 0,
+          lineLimit: 10,
+          linesIncluded: 1,
+          bytesRead: 7,
+          previewBytes: 7,
+          truncated: true,
+        },
+        bytes: 'cHJldmlldw',
+      },
+      previewProof: {
+        ...bundle.previewProof,
+        previewInclusion: {
+          offset: 0,
+          length: 7,
+          leafHash: 'e'.repeat(64),
+          path: [],
+        },
+      },
+    });
+
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /sealed stash package/i);
+  });
+
   it('rejects text previews whose bytes exceed the declared line limit', async () => {
     const body = { ...validBody(), fileName: 'notes.md', fileSize: 1024 };
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const previewText = Array.from({ length: 11 }, (_, index) => `line ${index + 1}`).join('\n');
     const previewBytes = Buffer.byteLength(previewText, 'utf8');
     const res = await createStash({
@@ -483,7 +623,7 @@ describe('POST /api/stash', () => {
 
   it('accepts seller-picked excerpt previews with a non-zero offset', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -527,7 +667,7 @@ describe('POST /api/stash', () => {
 
   it('rejects preview proof offsets that do not match generated preview metadata', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -572,7 +712,7 @@ describe('POST /api/stash', () => {
 
   it('rejects oversized preview inclusion paths', async () => {
     const body = validBody();
-    const bundle = validPreviewBundle(body);
+    const bundle = validSealedPreviewBundle(body);
     const res = await createStash({
       ...body,
       ...bundle,
@@ -726,5 +866,19 @@ describe('GET /api/stash/:id', () => {
     assert.deepEqual(data.generatedPreview, input.generatedPreview);
     assert.deepEqual(data.previewProof, input.previewProof);
     assert.equal(data.previewSecret, undefined);
+  });
+
+  it('returns the public sealed package locator for prepayment verification', async () => {
+    const input = { ...validBody(), ...validSealedPreviewBundle() };
+    const createRes = await createStash(input);
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}`);
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+
+    assert.equal(data.blobFormat, 'stashu-selective-v1');
+    assert.equal(data.sealedBlobUrl, input.blobUrl);
+    assert.equal(data.blobSha256, input.blobSha256);
   });
 });

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -2,6 +2,8 @@ import { Hono } from 'hono';
 import { v4 as uuidv4 } from 'uuid';
 import db from '../db/index.js';
 import { encrypt, decrypt } from '../lib/encryption.js';
+import { isPrivateOrReservedHostname } from '../lib/publicUrl.js';
+import { SEALED_BLOB_FORMAT, sealedStashFields } from '../lib/sealedBlob.js';
 import type { AuthVariables } from '../middleware/auth.js';
 import type {
   CreateStashRequest,
@@ -30,7 +32,6 @@ const MAX_PREVIEW_CHARS = 4_000;
 const MAX_MERKLE_PROOF_STEPS = 64;
 const MAX_TEXT_PREVIEW_RATIO = 0.5;
 const TEXT_LINE_LIMITS = new Set([4, 10, 20, 50]);
-const SEALED_BLOB_FORMAT = 'stashu-selective-v1';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -55,29 +56,7 @@ function isSafePublicBlobUrl(url: URL): boolean {
   }
   if (url.protocol !== 'https:') return false;
 
-  const hostname = url.hostname.toLowerCase();
-  if (
-    hostname === 'localhost' ||
-    hostname.endsWith('.localhost') ||
-    hostname.endsWith('.local') ||
-    hostname.includes(':')
-  ) {
-    return false;
-  }
-
-  const octets = hostname.split('.').map(Number);
-  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
-    return true;
-  }
-
-  return !(
-    octets[0] === 0 ||
-    octets[0] === 10 ||
-    octets[0] === 127 ||
-    (octets[0] === 169 && octets[1] === 254) ||
-    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
-    (octets[0] === 192 && octets[1] === 168)
-  );
+  return !isPrivateOrReservedHostname(url.hostname);
 }
 
 function base64UrlDecodedLength(value: string): number | null {
@@ -627,10 +606,7 @@ stashRoutes.get('/:id', async (c) => {
       fileName: decrypt(stash.file_name),
       fileSize: stash.file_size,
       priceSats: stash.price_sats,
-      blobFormat: stash.blob_format === SEALED_BLOB_FORMAT ? SEALED_BLOB_FORMAT : undefined,
-      sealedBlobUrl: stash.blob_format === SEALED_BLOB_FORMAT ? decrypt(stash.blob_url) : undefined,
-      blobSha256:
-        stash.blob_format === SEALED_BLOB_FORMAT ? (stash.blob_sha256 ?? undefined) : undefined,
+      ...sealedStashFields(stash),
       previewUrl: stash.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(stash.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(stash.preview_proof),

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -22,6 +22,7 @@ export const stashRoutes = new Hono<{ Variables: AuthVariables }>();
 
 const HASH_RE = /^[0-9a-f]{64}$/;
 const BASE64URL_RE = /^[A-Za-z0-9_-]*$/;
+const SEALED_SECRET_KEY_RE = /^stashu-selective-v1:[A-Za-z0-9+/]{43}=$/;
 const MAX_PREVIEW_PAYLOAD_JSON_LENGTH = 64 * 1024;
 const MAX_PREVIEW_BASE64URL_LENGTH = 64 * 1024;
 const MAX_PREVIEW_CONTENT_BYTES = 16 * 1024;
@@ -29,6 +30,7 @@ const MAX_PREVIEW_CHARS = 4_000;
 const MAX_MERKLE_PROOF_STEPS = 64;
 const MAX_TEXT_PREVIEW_RATIO = 0.5;
 const TEXT_LINE_LIMITS = new Set([4, 10, 20, 50]);
+const SEALED_BLOB_FORMAT = 'stashu-selective-v1';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -44,6 +46,38 @@ function isPositiveInteger(value: unknown, max = Number.MAX_SAFE_INTEGER): value
 
 function isHash(value: unknown): value is string {
   return typeof value === 'string' && HASH_RE.test(value);
+}
+
+function isSafePublicBlobUrl(url: URL): boolean {
+  if (url.username || url.password) return false;
+  if (process.env.ALLOW_INSECURE_BLOSSOM_URLS === '1') {
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  }
+  if (url.protocol !== 'https:') return false;
+
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.includes(':')
+  ) {
+    return false;
+  }
+
+  const octets = hostname.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+    return true;
+  }
+
+  return !(
+    octets[0] === 0 ||
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  );
 }
 
 function base64UrlDecodedLength(value: string): number | null {
@@ -120,18 +154,21 @@ function isStashProof(value: unknown): value is StashProof {
     'contentMerkleRoot',
     'contentLength',
     'chunkSize',
+    'sealedBlobSha256',
     'previewInclusion',
   ];
 
   return (
     hasOnlyKeys(value, keys) &&
-    value.version === 'stashu-preview-v1' &&
+    (value.version === 'stashu-preview-v1' || value.version === 'stashu-preview-v2') &&
     isHash(value.root) &&
     isHash(value.previewHash) &&
     isHash(value.contentMerkleRoot) &&
     isPositiveInteger(value.contentLength, 100 * 1024 * 1024) &&
     isPositiveInteger(value.chunkSize, 1024 * 1024) &&
     (value.chunkSize as number) >= 1024 &&
+    ((value.version === 'stashu-preview-v1' && value.sealedBlobSha256 === undefined) ||
+      (value.version === 'stashu-preview-v2' && isHash(value.sealedBlobSha256))) &&
     (value.previewInclusion === undefined || isPreviewInclusionProof(value.previewInclusion))
   );
 }
@@ -261,7 +298,11 @@ function validatePreviewBundle(body: CreateStashRequest): string | null {
   const fields = [body.generatedPreview, body.previewProof, body.previewSecret];
   const provided = fields.filter((field) => field !== undefined && field !== null).length;
 
-  if (provided === 0) return null;
+  if (provided === 0) {
+    return body.blobFormat === SEALED_BLOB_FORMAT
+      ? 'sealed stash packages require generated preview proof fields'
+      : null;
+  }
   if (provided !== fields.length) {
     return 'generatedPreview, previewProof, and previewSecret must be provided together';
   }
@@ -282,7 +323,25 @@ function validatePreviewBundle(body: CreateStashRequest): string | null {
     return 'previewProof content length must match fileSize';
   }
 
+  if (body.blobFormat === SEALED_BLOB_FORMAT) {
+    if (!body.blobSha256) {
+      return 'sealed stash packages require blobSha256';
+    }
+    if (
+      body.previewProof.version !== 'stashu-preview-v2' ||
+      body.previewProof.sealedBlobSha256 !== body.blobSha256
+    ) {
+      return 'sealed stash package hash must match previewProof';
+    }
+  } else if (body.previewProof.version === 'stashu-preview-v2') {
+    return 'stashu-preview-v2 proofs require a sealed stash package';
+  }
+
   if (body.generatedPreview.kind === 'text-peek') {
+    if (body.blobFormat !== SEALED_BLOB_FORMAT) {
+      return 'text previews require a sealed stash package';
+    }
+
     const { offset, previewBytes } = body.generatedPreview.metadata as {
       offset: number;
       previewBytes: number;
@@ -332,8 +391,9 @@ stashRoutes.post('/', async (c) => {
     }
 
     // Validate blobUrl is a valid URL
+    let blobUrl: URL;
     try {
-      new URL(body.blobUrl);
+      blobUrl = new URL(body.blobUrl);
     } catch {
       return c.json<APIResponse<never>>({ success: false, error: 'Invalid blobUrl' }, 400);
     }
@@ -376,6 +436,22 @@ stashRoutes.post('/', async (c) => {
       );
     }
 
+    if (body.blobFormat !== undefined && body.blobFormat !== SEALED_BLOB_FORMAT) {
+      return c.json<APIResponse<never>>({ success: false, error: 'Invalid blobFormat' }, 400);
+    }
+    if (body.blobFormat === SEALED_BLOB_FORMAT && !isSafePublicBlobUrl(blobUrl)) {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'Sealed stash blobUrl must be a public HTTPS URL' },
+        400
+      );
+    }
+    if (body.blobFormat === SEALED_BLOB_FORMAT && !SEALED_SECRET_KEY_RE.test(body.secretKey)) {
+      return c.json<APIResponse<never>>(
+        { success: false, error: 'Invalid sealed stash secretKey' },
+        400
+      );
+    }
+
     if (
       body.downloadWindowSeconds !== undefined &&
       !ALLOWED_DOWNLOAD_WINDOW_SECONDS.has(body.downloadWindowSeconds)
@@ -396,10 +472,10 @@ stashRoutes.post('/', async (c) => {
     const stmt = db.prepare(`
       INSERT INTO stashes (
         id, blob_url, blob_sha256, secret_key, seller_pubkey, price_sats,
-        title, description, file_name, file_size, preview_url,
+        title, description, file_name, file_size, blob_format, preview_url,
         generated_preview_payload, preview_proof, preview_secret, download_window_seconds
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -413,6 +489,7 @@ stashRoutes.post('/', async (c) => {
       body.description ? encrypt(body.description) : null,
       encrypt(body.fileName),
       body.fileSize,
+      body.blobFormat || null,
       body.previewUrl || null,
       body.generatedPreview ? stringifyEncryptedJson(body.generatedPreview) : null,
       body.previewProof ? stringifyEncryptedJson(body.previewProof) : null,
@@ -509,8 +586,9 @@ stashRoutes.get('/:id', async (c) => {
     const id = c.req.param('id');
 
     const stmt = db.prepare(`
-      SELECT id, title, description, file_name, file_size, price_sats, preview_url,
-             generated_preview_payload, preview_proof, download_window_seconds
+      SELECT id, title, description, file_name, file_size, price_sats, blob_url, blob_sha256,
+             blob_format, preview_url, generated_preview_payload, preview_proof,
+             download_window_seconds
       FROM stashes WHERE id = ?
     `);
 
@@ -522,6 +600,9 @@ stashRoutes.get('/:id', async (c) => {
       | 'file_name'
       | 'file_size'
       | 'price_sats'
+      | 'blob_url'
+      | 'blob_sha256'
+      | 'blob_format'
       | 'preview_url'
       | 'generated_preview_payload'
       | 'preview_proof'
@@ -546,6 +627,10 @@ stashRoutes.get('/:id', async (c) => {
       fileName: decrypt(stash.file_name),
       fileSize: stash.file_size,
       priceSats: stash.price_sats,
+      blobFormat: stash.blob_format === SEALED_BLOB_FORMAT ? SEALED_BLOB_FORMAT : undefined,
+      sealedBlobUrl: stash.blob_format === SEALED_BLOB_FORMAT ? decrypt(stash.blob_url) : undefined,
+      blobSha256:
+        stash.blob_format === SEALED_BLOB_FORMAT ? (stash.blob_sha256 ?? undefined) : undefined,
       previewUrl: stash.preview_url ?? undefined,
       generatedPreview: parseStoredJson<GeneratedPreviewPayload>(stash.generated_preview_payload),
       previewProof: parseStoredJson<StashProof>(stash.preview_proof),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -47,12 +47,13 @@ export interface GeneratedPreviewPayload {
 }
 
 export interface StashProof {
-  version: 'stashu-preview-v1';
+  version: 'stashu-preview-v1' | 'stashu-preview-v2';
   root: string;
   previewHash: string;
   contentMerkleRoot: string;
   contentLength: number;
   chunkSize: number;
+  sealedBlobSha256?: string;
   previewInclusion?: PreviewInclusionProof;
 }
 
@@ -83,6 +84,7 @@ export interface Stash {
   description?: string;
   fileName: string;
   fileSize: number;
+  blobFormat?: StashBlobFormat;
   previewUrl?: string;
   generatedPreview?: GeneratedPreviewPayload;
   previewProof?: StashProof;
@@ -98,6 +100,9 @@ export interface StashPublicInfo {
   fileName: string;
   fileSize: number;
   priceSats: number;
+  blobFormat?: StashBlobFormat;
+  sealedBlobUrl?: string;
+  blobSha256?: string;
   previewUrl?: string;
   generatedPreview?: GeneratedPreviewPayload;
   previewProof?: StashProof;
@@ -158,6 +163,7 @@ export interface CreateStashRequest {
   description?: string;
   fileName: string;
   fileSize: number;
+  blobFormat?: StashBlobFormat;
   previewUrl?: string;
   generatedPreview?: GeneratedPreviewPayload;
   previewProof?: StashProof;
@@ -165,6 +171,8 @@ export interface CreateStashRequest {
   // One of DOWNLOAD_WINDOW_OPTIONS. Omitted falls back to the default server-side.
   downloadWindowSeconds?: number;
 }
+
+export type StashBlobFormat = 'stashu-selective-v1';
 
 export interface CreateStashResponse {
   id: string;


### PR DESCRIPTION
## What changed

- introduce authenticated selective-reveal stash packages for Verified Peek v2
- bind preview proofs to the exact sealed Blossom blob and verify it before payment
- preserve legacy v1 unlock compatibility while clearly labeling weaker legacy peeks
- bound and hash-check Blossom downloads
- add Cashu mint request timeouts, retry-safe wallet initialization, and clearer 503 errors

## Why

The previous preview proof committed to plaintext content but did not bind the exact uploaded blob before payment. A swapped or unavailable blob could therefore be detected only after payment. Cashu mint requests could also hang indefinitely and concurrent initialization could cache an incompletely loaded wallet.

## Impact

New text peeks are embedded as public segments in an authenticated sealed package. Buyers verify the exact package before paying and verify the reconstructed file after unlock. Existing v1 stashes remain unlockable. Unresponsive mint requests now fail promptly and can be retried.

## Security model

This protects against detached preview/blob substitution, oversized Blossom responses, and indefinitely hanging mint calls. It does not prove before payment that encrypted hidden content is useful or decrypts successfully, and it does not protect against a fully compromised Stashu server holding its database encryption key.

## Validation

- `npm test` — 92 client tests and 114 server tests passed
- `npm run build`
- `npm run lint --workspace=client`
- `npx prettier --check .`
- `git diff --check`