### PR TITLE
add public manifest endpoint for stashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ Under the hood:
 For now, public previews are generated for text-like files. Other file types still
 get a no-public-preview commitment check after unlock.
 
+## Public Manifest
+
+Each stash exposes a versioned, machine-readable manifest at
+`GET /api/stash/:id/manifest` (`stashu-manifest-v1`) so external tools — a CLI,
+SDK, embed card, or agent — can inspect a stash and verify the same preview
+proofs the buyer UI checks. It contains public info only: id, title, price,
+file name/size, sealed blob URL and hash, generated preview and proof, payment
+methods, unlock/pay endpoint paths, and a `legacy` flag for pre-sealed stashes.
+
+Threat model: the manifest discloses nothing beyond what the existing public
+stash endpoint already returns to anyone holding the share link. It never
+contains the decrypt key, the proof secret (`contentSalt`), Cashu tokens, or
+the seller pubkey. Stash ids are random UUIDs and there is no global listing
+endpoint, so manifests are unlisted-by-link — though stashes a seller publishes
+to their storefront are intentionally discoverable via `GET /api/seller/:pubkey`.
+Manifests do NOT protect against a link holder republishing their contents.
+
 ## Tech Stack
 
 | Layer      | Technology                                |
@@ -216,6 +233,7 @@ docker compose up --build
 - [x] Seller dashboard, withdrawal, and auto-settlement
 - [x] Storefront publishing controls
 - [x] Verified Peek for text-like files
+- [x] Public machine-readable manifest per stash
 - [ ] Rich previews for images, PDFs, and archives
 - [ ] Stash lifecycle controls for editing, unpublishing, and deleting
 - [ ] Clearer fee estimates before withdrawal

--- a/server/src/routes/stash.test.ts
+++ b/server/src/routes/stash.test.ts
@@ -882,3 +882,99 @@ describe('GET /api/stash/:id', () => {
     assert.equal(data.blobSha256, input.blobSha256);
   });
 });
+
+describe('GET /api/stash/:id/manifest', () => {
+  it('returns 404 for non-existent stash', async () => {
+    const res = await app.request('/api/stash/nonexistent/manifest');
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).success, false);
+  });
+
+  it('returns a versioned manifest for a legacy stash', async () => {
+    const input = validBody();
+    const createRes = await createStash(input);
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}/manifest`);
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+
+    assert.equal(data.version, 'stashu-manifest-v1');
+    assert.equal(data.id, created.id);
+    assert.equal(data.title, input.title);
+    assert.deepEqual(data.file, { name: input.fileName, size: input.fileSize });
+    assert.equal(data.priceSats, input.priceSats);
+    assert.deepEqual(data.payment.methods, ['lightning', 'cashu']);
+    assert.deepEqual(data.payment.endpoints, {
+      invoice: { method: 'POST', path: `/api/pay/${created.id}/invoice` },
+      status: { method: 'GET', path: `/api/pay/${created.id}/status/{quoteId}` },
+      unlock: { method: 'POST', path: `/api/unlock/${created.id}` },
+      claim: { method: 'GET', path: `/api/unlock/${created.id}/claim?token={claimToken}` },
+    });
+    assert.equal(data.blob, undefined);
+    assert.deepEqual(data.preview, { kind: 'none' });
+    assert.equal(data.legacy, true);
+    assert.equal(res.headers.get('Cache-Control'), 'public, max-age=60');
+  });
+
+  it('returns the legacy image preview when present', async () => {
+    const previewUrl = 'https://blossom.example.com/preview.png';
+    const createRes = await createStash({ ...validBody(), previewUrl });
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}/manifest`);
+    const { data } = await res.json();
+    assert.deepEqual(data.preview, { kind: 'image', imageUrl: previewUrl });
+  });
+
+  it('returns sealed package and verified preview details', async () => {
+    const input = { ...validBody(), ...validSealedPreviewBundle() };
+    const createRes = await createStash(input);
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}/manifest`);
+    assert.equal(res.status, 200);
+    const { data } = await res.json();
+
+    assert.deepEqual(data.blob, {
+      format: 'stashu-selective-v1',
+      url: input.blobUrl,
+      sha256: input.blobSha256,
+    });
+    assert.equal(data.legacy, false);
+    assert.equal(data.preview.kind, 'generated');
+    assert.deepEqual(data.preview.generated, input.generatedPreview);
+    assert.deepEqual(data.preview.proof, input.previewProof);
+  });
+
+  it('never exposes secrets anywhere in the manifest', async () => {
+    const input = { ...validBody(), ...validSealedPreviewBundle() };
+    const createRes = await createStash(input);
+    const { data: created } = await createRes.json();
+
+    const res = await app.request(`/api/stash/${created.id}/manifest`);
+    const raw = await res.text();
+
+    assert.ok(!raw.includes(input.secretKey), 'decrypt key leaked');
+    assert.ok(!raw.includes(input.previewSecret.contentSalt), 'proof secret leaked');
+    assert.ok(!raw.includes(pk), 'seller pubkey leaked');
+
+    const { data } = JSON.parse(raw);
+    const allowed = new Set([
+      'version',
+      'id',
+      'title',
+      'description',
+      'file',
+      'priceSats',
+      'payment',
+      'blob',
+      'preview',
+      'legacy',
+      'downloadWindowSeconds',
+    ]);
+    for (const key of Object.keys(data)) {
+      assert.ok(allowed.has(key), `unexpected manifest field: ${key}`);
+    }
+  });
+});

--- a/server/src/routes/stash.ts
+++ b/server/src/routes/stash.ts
@@ -9,6 +9,7 @@ import type {
   CreateStashRequest,
   CreateStashResponse,
   GeneratedPreviewPayload,
+  StashManifest,
   StashProof,
   StashProofSecret,
   StashPublicInfo,
@@ -17,6 +18,7 @@ import type {
 import {
   ALLOWED_DOWNLOAD_WINDOW_SECONDS,
   DEFAULT_DOWNLOAD_WINDOW_SECONDS,
+  STASH_MANIFEST_VERSION,
 } from '../../../shared/types.js';
 import type { StashRow } from '../db/types.js';
 
@@ -559,34 +561,101 @@ stashRoutes.post('/:id/visibility', async (c) => {
   }
 });
 
+type PublicStashRow = Pick<
+  StashRow,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'file_name'
+  | 'file_size'
+  | 'price_sats'
+  | 'blob_url'
+  | 'blob_sha256'
+  | 'blob_format'
+  | 'preview_url'
+  | 'generated_preview_payload'
+  | 'preview_proof'
+  | 'download_window_seconds'
+>;
+
+// Only ever selects public columns — secret_key and preview_secret must
+// never be read here.
+function getPublicStashRow(id: string): PublicStashRow | null {
+  return db
+    .prepare(
+      `SELECT id, title, description, file_name, file_size, price_sats, blob_url, blob_sha256,
+              blob_format, preview_url, generated_preview_payload, preview_proof,
+              download_window_seconds
+       FROM stashes WHERE id = ?`
+    )
+    .get(id) as PublicStashRow | null;
+}
+
+// GET /api/stash/:id/manifest - Versioned machine-readable public manifest
+stashRoutes.get('/:id/manifest', async (c) => {
+  try {
+    const id = c.req.param('id');
+    const stash = getPublicStashRow(id);
+
+    if (!stash) {
+      return c.json<APIResponse<never>>({ success: false, error: 'Stash not found' }, 404);
+    }
+
+    const sealed = sealedStashFields(stash);
+    const generated = parseStoredJson<GeneratedPreviewPayload>(stash.generated_preview_payload);
+    const proof = parseStoredJson<StashProof>(stash.preview_proof);
+
+    const preview: StashManifest['preview'] =
+      generated && proof
+        ? { kind: 'generated', generated, proof }
+        : stash.preview_url
+          ? { kind: 'image', imageUrl: stash.preview_url }
+          : { kind: 'none' };
+
+    const manifest: StashManifest = {
+      version: STASH_MANIFEST_VERSION,
+      id: stash.id,
+      title: decrypt(stash.title),
+      description: stash.description ? decrypt(stash.description) : undefined,
+      file: {
+        name: decrypt(stash.file_name),
+        size: stash.file_size,
+      },
+      priceSats: stash.price_sats,
+      payment: {
+        methods: ['lightning', 'cashu'],
+        endpoints: {
+          invoice: { method: 'POST', path: `/api/pay/${stash.id}/invoice` },
+          status: { method: 'GET', path: `/api/pay/${stash.id}/status/{quoteId}` },
+          unlock: { method: 'POST', path: `/api/unlock/${stash.id}` },
+          claim: { method: 'GET', path: `/api/unlock/${stash.id}/claim?token={claimToken}` },
+        },
+      },
+      blob: sealed.blobFormat
+        ? {
+            format: sealed.blobFormat,
+            url: sealed.sealedBlobUrl!,
+            sha256: sealed.blobSha256,
+          }
+        : undefined,
+      preview,
+      legacy: sealed.blobFormat === undefined,
+      downloadWindowSeconds: stash.download_window_seconds ?? DEFAULT_DOWNLOAD_WINDOW_SECONDS,
+    };
+
+    c.header('Cache-Control', 'public, max-age=60');
+    return c.json<APIResponse<StashManifest>>({ success: true, data: manifest });
+  } catch (error) {
+    console.error('Error fetching stash manifest:', error);
+    return c.json<APIResponse<never>>({ success: false, error: 'Failed to fetch manifest' }, 500);
+  }
+});
+
 // GET /api/stash/:id - Get public stash info
 stashRoutes.get('/:id', async (c) => {
   try {
     const id = c.req.param('id');
-
-    const stmt = db.prepare(`
-      SELECT id, title, description, file_name, file_size, price_sats, blob_url, blob_sha256,
-             blob_format, preview_url, generated_preview_payload, preview_proof,
-             download_window_seconds
-      FROM stashes WHERE id = ?
-    `);
-
-    const stash = stmt.get(id) as Pick<
-      StashRow,
-      | 'id'
-      | 'title'
-      | 'description'
-      | 'file_name'
-      | 'file_size'
-      | 'price_sats'
-      | 'blob_url'
-      | 'blob_sha256'
-      | 'blob_format'
-      | 'preview_url'
-      | 'generated_preview_payload'
-      | 'preview_proof'
-      | 'download_window_seconds'
-    > | null;
+    const stash = getPublicStashRow(id);
 
     if (!stash) {
       return c.json<APIResponse<never>>(

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -112,6 +112,58 @@ export interface StashPublicInfo {
 }
 
 // ============================================
+// Public manifest
+// ============================================
+
+export const STASH_MANIFEST_VERSION = 'stashu-manifest-v1' as const;
+
+// Paths are relative to the API origin the manifest was fetched from and may
+// contain {placeholder} template segments.
+export interface ManifestEndpoint {
+  method: 'GET' | 'POST';
+  path: string;
+}
+
+export type StashManifestPreview =
+  | { kind: 'generated'; generated: GeneratedPreviewPayload; proof: StashProof }
+  | { kind: 'image'; imageUrl: string }
+  | { kind: 'none' };
+
+// Machine-readable public shape of a stash for external tools (CLI, SDK,
+// embed cards). Public info only — never contains the decrypt key, proof
+// secret (contentSalt), Cashu tokens, or the seller pubkey.
+export interface StashManifest {
+  version: typeof STASH_MANIFEST_VERSION;
+  id: string;
+  title: string;
+  description?: string;
+  file: {
+    name: string;
+    size: number;
+  };
+  priceSats: number;
+  payment: {
+    methods: ['lightning', 'cashu'];
+    endpoints: {
+      invoice: ManifestEndpoint;
+      status: ManifestEndpoint;
+      unlock: ManifestEndpoint;
+      claim: ManifestEndpoint;
+    };
+  };
+  // Present only for sealed (stashu-selective-v1) packages
+  blob?: {
+    format: StashBlobFormat;
+    url: string;
+    sha256?: string;
+  };
+  preview: StashManifestPreview;
+  // True for pre-sealed-package stashes
+  legacy: boolean;
+  downloadWindowSeconds: number;
+}
+
+// ============================================
 // Re-download window
 // ============================================
 


### PR DESCRIPTION
Closes #51.

Adds `GET /api/stash/:id/manifest` returning a versioned `stashu-manifest-v1` document so external tools (CLI, SDK, embed cards, agent flows) can inspect a stash without depending on the UI's response shape.

## What's in the manifest
- id, title, description, file name/size, priceSats
- payment methods plus `{method, path}` endpoint templates for invoice, status (`{quoteId}`), unlock, and claim (`{claimToken}`)
- sealed blob locator (format, url, sha256) for `stashu-selective-v1` packages
- preview as a discriminated union: `generated` (peek payload + proof), `image`, or `none`
- `legacy` flag for pre-sealed-package stashes, plus `downloadWindowSeconds`

## Security
Public info only — the row query allowlists columns so `secret_key` and `preview_secret` are never read on this path. Tests assert the raw response contains neither secret nor the seller pubkey, and that top-level fields match the documented shape. README documents the threat model (no global listing endpoint; storefront-published stashes remain intentionally discoverable via `GET /api/seller/:pubkey`).

No changes to buyer/seller flow or payment rails. 119 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)